### PR TITLE
Fixed issues when running compilation steps on a non-CPR computer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@ Proton communication protocol.
 
 Documentation is available [here](https://docs.clearpathrobotics.com/docs_proton/)
 
+## Requirements
+
+Proton has several external requirements for both code generation and runtime usage
+
+### C
+- `nanopb` (included): lightweight protobuf library and code generator for protonc
+
+### C++
+- `libboost-all-dev`: Specifically for `boost/asio.hpp`: an asynchronous serial input/output executor
+- `protobuf-compiler`: Used at both build-time (for generating code versions of .proto files), and as a general protobuf library for protoncpp
+- `libyaml-cpp-dev`: For parsing bundle config files during the code generation step.
+
+### Python
+- `protobuf`: pip package for `nanopb` code generator
+- `pyyaml`: yaml file parser
+
 ## Build steps
 
 Build all C/C++ code with:
@@ -13,6 +29,14 @@ mkdir build
 cd build
 cmake ..
 make
+```
+
+> **NOTE:** CMake does not check for Python packages. If you run into problems running the `nanopb` code generator, install the above Python dependencies in a `venv`
+
+```
+python3 -m venv venv
+. venv/bin/activate
+pip3 install protobuf pyyaml
 ```
 
 ## Run Examples

--- a/protoncpp/CMakeLists.txt
+++ b/protoncpp/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 
 # YAML-CPP
 find_package(yaml-cpp REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system thread)
 
 # -------------------------------
 # Proto files

--- a/protoncpp/include/protoncpp/transport/serial.hpp
+++ b/protoncpp/include/protoncpp/transport/serial.hpp
@@ -25,10 +25,11 @@
 #include <termios.h>
 #include <unistd.h>
 #include <iostream>
-#include <asio.hpp>
 #include <optional>
 #include <thread>
 #include <vector>
+
+#include <boost/asio.hpp>
 
 #include "protoncpp/transport/transport.hpp"
 
@@ -61,8 +62,8 @@ private:
   std::optional<std::vector<uint8_t>> buildPacket(const uint8_t *buf, const size_t& len);
 
   serial_device device;
-  asio::io_context io_context_;
-  asio::serial_port port_;
+  boost::asio::io_context io_context_;
+  boost::asio::serial_port port_;
   std::thread io_thread_;
 };
 

--- a/protoncpp/src/bundle_manager.cpp
+++ b/protoncpp/src/bundle_manager.cpp
@@ -18,6 +18,8 @@
 
 #include "protoncpp/bundle_manager.hpp"
 
+#include <mutex>
+
 using namespace proton;
 
 void BundleManager::addBundle(BundleConfig config) {

--- a/protoncpp/src/config.cpp
+++ b/protoncpp/src/config.cpp
@@ -19,6 +19,7 @@
 #include "protoncpp/config.hpp"
 
 #include <iostream>
+#include <mutex>
 
 namespace YAML {
 

--- a/protoncpp/src/transport/serial.cpp
+++ b/protoncpp/src/transport/serial.cpp
@@ -22,8 +22,6 @@
 #include <string.h>
 #include <vector>
 
-#include <asio.hpp>
-
 using namespace proton;
 
 SerialTransport::SerialTransport(serial_device device)
@@ -95,7 +93,7 @@ proton_status_e SerialTransport::write(const uint8_t *buf, const size_t &len,
   auto packet = ret.value();
 
   try {
-    if (asio::write(port_, asio::buffer(packet, packet.size())) != packet.size())
+    if (boost::asio::write(port_, boost::asio::buffer(packet, packet.size())) != packet.size())
     {
       return PROTON_WRITE_ERROR;
     }
@@ -126,11 +124,11 @@ proton_status_e SerialTransport::read(uint8_t *buf, const size_t &len,
     // Synchronize to start of frame
     do
     {
-      asio::read(port_, asio::buffer(header, 1));
+      boost::asio::read(port_, boost::asio::buffer(header, 1));
     } while (header[0] != FRAME_HEADER1);
 
     // Read the rest of the header
-    if (asio::read(port_, asio::buffer(&header[1], HEADER_OVERHEAD - 1)) != HEADER_OVERHEAD - 1)
+    if (boost::asio::read(port_, boost::asio::buffer(&header[1], HEADER_OVERHEAD - 1)) != HEADER_OVERHEAD - 1)
     {
       return PROTON_READ_ERROR;
     }
@@ -154,7 +152,7 @@ proton_status_e SerialTransport::read(uint8_t *buf, const size_t &len,
   // Read the payload
   try
   {
-    if (asio::read(port_, asio::buffer(buf, payload_len)) != payload_len)
+    if (boost::asio::read(port_, boost::asio::buffer(buf, payload_len)) != payload_len)
     {
       return PROTON_READ_ERROR;
     }
@@ -169,7 +167,7 @@ proton_status_e SerialTransport::read(uint8_t *buf, const size_t &len,
   // Read CRC16
   try
   {
-    if (asio::read(port_, asio::buffer(crc, CRC16_OVERHEAD)) != CRC16_OVERHEAD)
+    if (boost::asio::read(port_, boost::asio::buffer(crc, CRC16_OVERHEAD)) != CRC16_OVERHEAD)
     {
       return PROTON_READ_ERROR;
     }


### PR DESCRIPTION
Added the following fixes:

- Added cmake checks for `Boost` so it can find `asio.hpp`
- Updated asio.hpp include path and namespacing to `#include <boost/asio.hpp>` (I don't know how this worked otherwise...)
- Replaced missing `#include <mutex>` in some files, which can be caught with different versions of gcc.
- Added readme instructions on how to add python dependencies for running nanopb generator in protonc.