### PR TITLE
Add minimal package.xml for workspace discovery

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>proton</name>
+  <version>1.0.0</version>
+  <description>ROS-agnostic peer to peer messaging protocol</description>
+  <maintainer email="thomas.wallis@rockwellautomation.com">Tom Wallis</maintainer>
+  <license>Apache 2.0</license>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
This is so proton can be discovered in a workspace when using `PROTON_VENDOR_USE_LOCAL` Does nothing to change how it builds.