### PR TITLE
Fix failing decode id test

### DIFF
--- a/tests/protonc/proton_test.cpp
+++ b/tests/protonc/proton_test.cpp
@@ -18,11 +18,6 @@
 
 #include "protonc/utils.hpp"
 
-uint8_t read_buf[PROTON_MAX_MESSAGE_SIZE];
-uint8_t write_buf[PROTON_MAX_MESSAGE_SIZE];
-proton_buffer_t proton_producer_buffer = {write_buf, PROTON_MAX_MESSAGE_SIZE};
-proton_buffer_t proton_consumer_buffer = {read_buf, PROTON_MAX_MESSAGE_SIZE};
-
 TEST(PROTONC_Proton, InitBundle) {
   // Create structs to hold bundle and signals
   proton_bundle_handle_t test_bundle_handle;
@@ -41,6 +36,12 @@ TEST(PROTONC_Proton, InitBundle) {
 }
 
 TEST(PROTONC_Proton, InitNode) {
+  uint8_t write_buf[PROTON_MAX_MESSAGE_SIZE];
+  proton_buffer_t proton_producer_buffer = {write_buf, PROTON_MAX_MESSAGE_SIZE};
+
+  uint8_t read_buf[PROTON_MAX_MESSAGE_SIZE];
+  proton_buffer_t proton_consumer_buffer = {read_buf, PROTON_MAX_MESSAGE_SIZE};
+
   proton_node_t producer_node = PROTON__NODE__PRODUCER__DEFAULT_VALUE;
   proton_peer_t producer_peers[PROTON__PEER__COUNT] = {PROTON__NODE__CONSUMER__PEER__DEFAULT_VALUE};
 
@@ -67,6 +68,9 @@ TEST(PROTONC_Proton, InitNode) {
 }
 
 TEST(PROTONC_Proton, Encode) {
+  uint8_t write_buf[PROTON_MAX_MESSAGE_SIZE];
+  proton_buffer_t proton_producer_buffer = {write_buf, PROTON_MAX_MESSAGE_SIZE};
+
   // Create structs to hold bundle and signals
   proton_bundle_handle_t test_bundle_handle;
   proton_signal_handle_t test_signal_handles[PROTON__BUNDLE__VALUE_TEST__SIGNAL__COUNT];
@@ -147,6 +151,9 @@ TEST(PROTONC_Proton, Encode) {
 }
 
 TEST(PROTONC_Proton, DecodeId) {
+  uint8_t write_buf[PROTON_MAX_MESSAGE_SIZE];
+  proton_buffer_t proton_producer_buffer = {write_buf, PROTON_MAX_MESSAGE_SIZE};
+
   // Create structs to hold bundle and signals
   proton_bundle_handle_t test_bundle_handle;
   proton_signal_handle_t test_signal_handle;
@@ -174,6 +181,9 @@ TEST(PROTONC_Proton, DecodeId) {
 }
 
 TEST(PROTONC_Proton, Decode) {
+  uint8_t write_buf[PROTON_MAX_MESSAGE_SIZE];
+  proton_buffer_t proton_producer_buffer = {write_buf, PROTON_MAX_MESSAGE_SIZE};
+
   // Create structs to hold bundle and signals
   proton_bundle_handle_t test_bundle_handle;
   proton_signal_handle_t test_signal_handles[PROTON__BUNDLE__VALUE_TEST__SIGNAL__COUNT];

--- a/tests/protonc/proton_test.cpp
+++ b/tests/protonc/proton_test.cpp
@@ -160,7 +160,7 @@ TEST(PROTONC_Proton, DecodeId) {
   proton_bundle_value_test_t test_bundle;
 
   // Initialise bundle with ID 0x123
-  proton_status_e status = proton_init_bundle(&test_bundle_handle, 0x123, &test_signal_handle, 0, 0, 0);
+  proton_status_e status = proton_init_bundle(&test_bundle_handle, 0x123, &test_signal_handle, 1, 0, 0);
   EXPECT_EQ(status, PROTON_OK);
 
   // Encode bundle

--- a/tests/protoncpp/bundle_test.cpp
+++ b/tests/protoncpp/bundle_test.cpp
@@ -20,10 +20,11 @@
 
 using namespace proton;
 
-std::map<std::string, BundleHandle> bundles;
-
 TEST(BundleTests, Serialize)
 {
+  std::map<std::string, BundleHandle> bundles;
+  bundles = getBundles(CONFIG_FILE);
+
   auto& handle = bundles.at("value_test");
   auto bundle = handle.getBundlePtr();
 
@@ -40,6 +41,5 @@ TEST(BundleTests, Serialize)
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
-  bundles = getBundles(CONFIG_FILE);
   return RUN_ALL_TESTS();
 }

--- a/tests/protoncpp/signal_test.cpp
+++ b/tests/protoncpp/signal_test.cpp
@@ -19,9 +19,9 @@
 
 using namespace proton;
 
-std::map<std::string, BundleHandle> bundles;
-
 TEST(SignalValues, DoubleValue) {
+  std::map<std::string, BundleHandle> bundles;
+  bundles = getBundles(CONFIG_FILE);
   auto& bundle = bundles.at("value_test");
   auto& signal = bundle.getSignal("double_value");
 
@@ -37,6 +37,8 @@ TEST(SignalValues, DoubleValue) {
 }
 
 TEST(SignalValues, FloatValue) {
+  std::map<std::string, BundleHandle> bundles;
+  bundles = getBundles(CONFIG_FILE);
   auto& bundle = bundles.at("value_test");
   auto& signal = bundle.getSignal("float_value");
 
@@ -52,6 +54,8 @@ TEST(SignalValues, FloatValue) {
 }
 
 TEST(SignalValues, Int32Value) {
+  std::map<std::string, BundleHandle> bundles;
+  bundles = getBundles(CONFIG_FILE);
   auto& bundle = bundles.at("value_test");
   auto& signal = bundle.getSignal("int32_value");
 
@@ -74,6 +78,8 @@ TEST(SignalValues, Int32Value) {
 }
 
 TEST(SignalValues, Int64Value) {
+  std::map<std::string, BundleHandle> bundles;
+  bundles = getBundles(CONFIG_FILE);
   auto& bundle = bundles.at("value_test");
   auto& signal = bundle.getSignal("int64_value");
 
@@ -96,6 +102,8 @@ TEST(SignalValues, Int64Value) {
 }
 
 TEST(SignalValues, Uint32Value) {
+  std::map<std::string, BundleHandle> bundles;
+  bundles = getBundles(CONFIG_FILE);
   auto& bundle = bundles.at("value_test");
   auto& signal = bundle.getSignal("uint32_value");
 
@@ -111,6 +119,8 @@ TEST(SignalValues, Uint32Value) {
 }
 
 TEST(SignalValues, Uint64Value) {
+  std::map<std::string, BundleHandle> bundles;
+  bundles = getBundles(CONFIG_FILE);
   auto& bundle = bundles.at("value_test");
   auto& signal = bundle.getSignal("uint64_value");
 
@@ -126,6 +136,8 @@ TEST(SignalValues, Uint64Value) {
 }
 
 TEST(SignalValues, BoolValue) {
+  std::map<std::string, BundleHandle> bundles;
+  bundles = getBundles(CONFIG_FILE);
   auto& bundle = bundles.at("value_test");
   auto& signal = bundle.getSignal("bool_value");
 
@@ -141,6 +153,8 @@ TEST(SignalValues, BoolValue) {
 }
 
 TEST(SignalValues, StringValue) {
+  std::map<std::string, BundleHandle> bundles;
+  bundles = getBundles(CONFIG_FILE);
   auto& bundle = bundles.at("value_test");
   auto& signal = bundle.getSignal("string_value");
 
@@ -153,6 +167,8 @@ TEST(SignalValues, StringValue) {
 }
 
 TEST(SignalValues, BytesValue) {
+  std::map<std::string, BundleHandle> bundles;
+  bundles = getBundles(CONFIG_FILE);
   auto& bundle = bundles.at("value_test");
   auto& signal = bundle.getSignal("bytes_value");
 
@@ -165,6 +181,8 @@ TEST(SignalValues, BytesValue) {
 }
 
 TEST(SignalValues, ListDoubleValue) {
+  std::map<std::string, BundleHandle> bundles;
+  bundles = getBundles(CONFIG_FILE);
   auto& bundle = bundles.at("value_test");
   auto& signal = bundle.getSignal("list_double_value");
 
@@ -177,6 +195,8 @@ TEST(SignalValues, ListDoubleValue) {
 }
 
 TEST(SignalValues, ListFloatValue) {
+  std::map<std::string, BundleHandle> bundles;
+  bundles = getBundles(CONFIG_FILE);
   auto& bundle = bundles.at("value_test");
   auto& signal = bundle.getSignal("list_float_value");
 
@@ -189,6 +209,8 @@ TEST(SignalValues, ListFloatValue) {
 }
 
 TEST(SignalValues, ListInt32Value) {
+  std::map<std::string, BundleHandle> bundles;
+  bundles = getBundles(CONFIG_FILE);
   auto& bundle = bundles.at("value_test");
   auto& signal = bundle.getSignal("list_int32_value");
 
@@ -201,6 +223,8 @@ TEST(SignalValues, ListInt32Value) {
 }
 
 TEST(SignalValues, ListInt64Value) {
+  std::map<std::string, BundleHandle> bundles;
+  bundles = getBundles(CONFIG_FILE);
   auto& bundle = bundles.at("value_test");
   auto& signal = bundle.getSignal("list_int64_value");
 
@@ -213,6 +237,8 @@ TEST(SignalValues, ListInt64Value) {
 }
 
 TEST(SignalValues, ListUint32Value) {
+  std::map<std::string, BundleHandle> bundles;
+  bundles = getBundles(CONFIG_FILE);
   auto& bundle = bundles.at("value_test");
   auto& signal = bundle.getSignal("list_uint32_value");
 
@@ -225,6 +251,8 @@ TEST(SignalValues, ListUint32Value) {
 }
 
 TEST(SignalValues, ListUint64Value) {
+  std::map<std::string, BundleHandle> bundles;
+  bundles = getBundles(CONFIG_FILE);
   auto& bundle = bundles.at("value_test");
   auto& signal = bundle.getSignal("list_uint64_value");
 
@@ -237,6 +265,8 @@ TEST(SignalValues, ListUint64Value) {
 }
 
 TEST(SignalValues, ListBoolValue) {
+  std::map<std::string, BundleHandle> bundles;
+  bundles = getBundles(CONFIG_FILE);
   auto& bundle = bundles.at("value_test");
   auto& signal = bundle.getSignal("list_bool_value");
 
@@ -249,6 +279,8 @@ TEST(SignalValues, ListBoolValue) {
 }
 
 TEST(SignalValues, ListStringValue) {
+  std::map<std::string, BundleHandle> bundles;
+  bundles = getBundles(CONFIG_FILE);
   auto& bundle = bundles.at("value_test");
   auto& signal = bundle.getSignal("list_string_value");
 
@@ -261,6 +293,8 @@ TEST(SignalValues, ListStringValue) {
 }
 
 TEST(SignalValues, ListBytesValue) {
+  std::map<std::string, BundleHandle> bundles;
+  bundles = getBundles(CONFIG_FILE);
   auto& bundle = bundles.at("value_test");
   auto& signal = bundle.getSignal("list_bytes_value");
 
@@ -275,6 +309,5 @@ TEST(SignalValues, ListBytesValue) {
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
-  bundles = getBundles(CONFIG_FILE);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
PROTONC_Proton::DecodeID unit test was trying to encode a bundle that had a nullptr for associated signals. This is caused by initializing the bundle in `proton_init_bundle` with `0` as the number of associated signals, rather than `1`.

Also moved mutable global variables to the tests that use them, to allow for test randomization at some point in the glorious future. 