### PR TITLE
Add Proton message, not used yet

### DIFF
--- a/proto/proton.proto
+++ b/proto/proton.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package proton;
+
+import "bundle.proto";
+
+// Top level proton message, all possible proton functionalities are contained in here.
+message Proton {
+  oneof operation {
+    Bundle bundle = 1;
+    // Reserved for future operation types
+  }
+}


### PR DESCRIPTION
Part of the larger proton re-architecture [here](https://otto-ra.atlassian.net/wiki/spaces/PFT/pages/344948755/Proton+Reorganization+and+Core+Library) (internal CPR/OTTO employee eyes only 👀 )

This creates the `Proton` top-level message for proton. This will be the top-level message serialized/deserialized by `proton_core`

The neat thing is that [according to the protobuf documentation](https://protobuf.dev/programming-guides/encoding/#oneofs), encoding a `oneof` incurs zero overhead penalties on the wire. Efficiency!

This PR does **NOT** effect current functionality. It's just boilerplate for incoming PR's as proton_core is fleshed out.