### PR TITLE
FIX: Remove the -n flag for node code autogeneration

### DIFF
--- a/cmake/protonFunctions.cmake
+++ b/cmake/protonFunctions.cmake
@@ -1,5 +1,5 @@
 
-function(protonc_generator GENERATED_FILES CONFIG_FILE GENERATED_FOLDER TARGET GENERATE_NODE)
+function(protonc_generator GENERATED_FILES CONFIG_FILE GENERATED_FOLDER TARGET)
   find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
   # Get the directory where this function is defined (proton/cmake)
@@ -20,9 +20,8 @@ function(protonc_generator GENERATED_FILES CONFIG_FILE GENERATED_FOLDER TARGET G
       -c ${CONFIG_FILE}
       -d ${GENERATED_FOLDER}
       -t ${TARGET}
-      -n ${GENERATE_NODE}
     DEPENDS ${CONFIG_FILE} # Regenerate if config changes
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMENT "Running Python script: ${Python3_EXECUTABLE} ${PROTONC_GENERATOR_SCRIPT} -c ${CONFIG_FILE} -d ${GENERATED_FOLDER} -t ${TARGET} -n ${GENERATE_NODE}"
+    COMMENT "Running Python script: ${Python3_EXECUTABLE} ${PROTONC_GENERATOR_SCRIPT} -c ${CONFIG_FILE} -d ${GENERATED_FOLDER} -t ${TARGET}"
   )
 endfunction()

--- a/examples/a300/CMakeLists.txt
+++ b/examples/a300/CMakeLists.txt
@@ -29,7 +29,7 @@ set(GENERATED_C_FILES
   "${GENERATED_FOLDER}/proton__a300_mcu.h"
 )
 
-protonc_generator("${GENERATED_C_FILES}" ${CONFIG_FILE} ${GENERATED_FOLDER} "mcu" True)
+protonc_generator("${GENERATED_C_FILES}" ${CONFIG_FILE} ${GENERATED_FOLDER} "mcu")
 
 add_executable(a300_mcu_c
   a300_mcu.c

--- a/examples/j100/CMakeLists.txt
+++ b/examples/j100/CMakeLists.txt
@@ -28,7 +28,7 @@ set(GENERATED_C_FILES
   "${GENERATED_FOLDER}/proton__j100_mcu.h"
 )
 
-protonc_generator("${GENERATED_C_FILES}" ${CONFIG_FILE} ${GENERATED_FOLDER} "mcu" True)
+protonc_generator("${GENERATED_C_FILES}" ${CONFIG_FILE} ${GENERATED_FOLDER} "mcu")
 
 add_executable(j100_mcu_c
   j100_mcu.c

--- a/examples/multi_node/CMakeLists.txt
+++ b/examples/multi_node/CMakeLists.txt
@@ -56,7 +56,7 @@ set(GENERATED_C_FILES
   "${GENERATED_FOLDER}/proton__multi_node_node1.h"
 )
 
-protonc_generator("${GENERATED_C_FILES}" ${CONFIG_FILE} ${GENERATED_FOLDER} "node1" True)
+protonc_generator("${GENERATED_C_FILES}" ${CONFIG_FILE} ${GENERATED_FOLDER} "node1")
 
 add_executable(multi_node_1_c
   multi_node_1.c
@@ -84,7 +84,7 @@ set(GENERATED_C_FILES
   "${GENERATED_FOLDER}/proton__multi_node_node2.h"
 )
 
-protonc_generator("${GENERATED_C_FILES}" ${CONFIG_FILE} ${GENERATED_FOLDER} "node2" True)
+protonc_generator("${GENERATED_C_FILES}" ${CONFIG_FILE} ${GENERATED_FOLDER} "node2")
 
 add_executable(multi_node_2_c
   multi_node_2.c
@@ -112,7 +112,7 @@ set(GENERATED_C_FILES
   "${GENERATED_FOLDER}/proton__multi_node_node3.h"
 )
 
-protonc_generator("${GENERATED_C_FILES}" ${CONFIG_FILE} ${GENERATED_FOLDER} "node3" True)
+protonc_generator("${GENERATED_C_FILES}" ${CONFIG_FILE} ${GENERATED_FOLDER} "node3")
 
 add_executable(multi_node_3_c
   multi_node_3.c

--- a/generator_scripts/generator.py
+++ b/generator_scripts/generator.py
@@ -141,14 +141,6 @@ def main():
         help='Target node for generation',
     )
 
-    parser.add_argument(
-        '-n',
-        '--node',
-        type=bool,
-        default=False,
-        help='Generate code for node and transport implementation',
-    )
-
     args = parser.parse_args()
 
     config_path = args.config

--- a/protonc/CMakeLists.txt
+++ b/protonc/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 
 set(PROTONC_GENERATOR ${CMAKE_SOURCE_DIR}/generator_scripts/generator.py)
 
-function(protonc_generator GENERATED_FILES CONFIG_FILE GENERATED_FOLDER TARGET GENERATE_NODE)
+function(protonc_generator GENERATED_FILES CONFIG_FILE GENERATED_FOLDER TARGET)
   find_package(Python3 REQUIRED COMPONENTS Interpreter)
   set(PROTONC_GENERATOR ${CMAKE_SOURCE_DIR}/generator_scripts/generator.py)
   # Add a custom target to execute the script
@@ -43,10 +43,9 @@ function(protonc_generator GENERATED_FILES CONFIG_FILE GENERATED_FOLDER TARGET G
       -c ${CONFIG_FILE}
       -d ${GENERATED_FOLDER}
       -t ${TARGET}
-      -n ${GENERATE_NODE}
     DEPENDS ${CONFIG_FILE} # Regenerate if config changes
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMENT "Running Python script: ${Python3_EXECUTABLE} ${PROTONC_GENERATOR} -c ${CONFIG_FILE} -d ${GENERATED_FOLDER} -t ${TARGET} -n ${GENERATE_NODE}"
+    COMMENT "Running Python script: ${Python3_EXECUTABLE} ${PROTONC_GENERATOR} -c ${CONFIG_FILE} -d ${GENERATED_FOLDER} -t ${TARGET}"
   )
 endfunction()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ set(GENERATED_C_FILES
   "${GENERATED_FOLDER}/proton__test_producer.h"
 )
 
-protonc_generator("${GENERATED_C_FILES}" ${CONFIG_FILE} ${GENERATED_FOLDER} "producer" True)
+protonc_generator("${GENERATED_C_FILES}" ${CONFIG_FILE} ${GENERATED_FOLDER} "producer")
 
 ### Signals
 add_executable(signal_test_c


### PR DESCRIPTION
There were 0 instances of it being set to `false`, internal or external. Even with the original code generator. The original `protonc_generator` didn't use it either.