### PR TITLE
FIX: CORE-37207 remove heartbeat bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This example consists of 3 nodes communicating with each other over both UDP and
 To simulate serial transport, create virtual serial ports with `socat`:
 
 ```
-socat PTY,link=/tmp/ttyPC,raw,echo=0 PTY,link=/tmp/ttyMCU,raw,echo=0
+socat PTY,link=/tmp/ttyNode1,raw,echo=0 PTY,link=/tmp/ttyNode3,raw,echo=0
 ```
 
 #### Terminal 2 - Node 1

--- a/examples/a300/a300.yaml
+++ b/examples/a300/a300.yaml
@@ -1,17 +1,11 @@
 nodes:
   - name: pc
-    heartbeat:
-      enabled: true
-      period: 1000
     endpoints:
       - id: 0
         type: udp4
         ip: 127.0.0.1
         port: 11416
   - name: mcu
-    heartbeat:
-      enabled: true
-      period: 100
     endpoints:
       - id: 0
         type: udp4
@@ -23,6 +17,18 @@ connections:
     second: {node: pc, id: 0}
 
 bundles:
+  - name: mcu_heartbeat
+    id: 0x000
+    producers: [mcu]
+    consumers: [pc]
+    signals:
+      - {name: heartbeat, id: 0, type: uint32}
+  - name: pc_heartbeat
+    id: 0x001
+    producers: [pc]
+    consumers: [mcu]
+    signals:
+      - {name: heartbeat, id: 1, type: uint32}
   - name: log
     id: 0x100
     producers: [mcu]

--- a/examples/a300/a300_mcu.c
+++ b/examples/a300/a300_mcu.c
@@ -58,6 +58,7 @@ typedef enum
   CALLBACK_PINOUT_COMMAND,
   CALLBACK_CMD_SHUTDOWN,
   CALLBACK_CLEAR_NEEDS_RESET,
+  CALLBACK_PC_HEARTBEAT,
   CALLBACK_COUNT
 } callback_e;
 
@@ -137,6 +138,7 @@ void proton_bundle_pc_heartbeat_callback(void * context)
 {
   context_t * c = (context_t *)context;
   printf("Heartbeat received %u\r\n", c->bundles.pc_heartbeat_bundle.heartbeat);
+  c->cb_counts[CALLBACK_PC_HEARTBEAT]++;
   c->node->peers[PROTON__PEER__PC].state = PROTON_NODE_ACTIVE;
   c->last_pc_heartbeat = time(NULL);
 }
@@ -337,6 +339,24 @@ void update_pinout_state(proton_node_t * node, proton_bundle_pinout_state_t * pi
 }
 
 /**
+ * @brief Updates and sends heartbeat bundle data
+ * @param node Pointer to proton_node_t structure
+ * @param heartbeat_bundle Pointer to heartbeat bundle to update
+ */
+void update_mcu_heartbeat(
+  proton_node_t * node, proton_bundle_mcu_heartbeat_t * mcu_heartbeat_bundle)
+{
+  if (!mcu_heartbeat_bundle)
+  {
+    return;
+  }
+
+  mcu_heartbeat_bundle->heartbeat += 1;
+
+  proton_bundle_send(node, PROTON__BUNDLE__MCU_HEARTBEAT);
+}
+
+/**
  * @brief Establishes PC transport connection.
  * @return PROTON_OK if connection successful, error code otherwise.
  */
@@ -511,8 +531,9 @@ void * timer_1hz(void * arg)
     update_alerts(context->node, &context->bundles.alerts_bundle);
     msleep(1000);
 
-    if (time(NULL) - context->last_pc_heartbeat > PROTON__NODE__PC__HEARTBEAT__PERIOD / 1000)
+    if (time(NULL) - context->last_pc_heartbeat > 1)
     {
+      printf("Lost PC heartbeat\r\n");
       context->node->peers[PROTON__PEER__PC].state = PROTON_NODE_INACTIVE;
     }
   }
@@ -541,9 +562,8 @@ void * timer_10hz(void * arg)
     update_power(context->node, &context->bundles.power_bundle);
     update_temperature(context->node, &context->bundles.temperature_bundle);
     update_pinout_state(context->node, &context->bundles.pinout_state_bundle);
+    update_mcu_heartbeat(context->node, &context->bundles.mcu_heartbeat_bundle);
 
-    context->bundles.mcu_heartbeat_bundle.heartbeat++;
-    proton_bundle_send(context->node, PROTON_HEARTBEAT_ID);
     msleep(100);
   }
 
@@ -583,6 +603,7 @@ void * stats(void * arg)
     printf("pinout_command: %d\r\n", context->cb_counts[CALLBACK_PINOUT_COMMAND]);
     printf("cmd_shutdown: %d\r\n", context->cb_counts[CALLBACK_CMD_SHUTDOWN]);
     printf("clear_needs_reset: %d\r\n", context->cb_counts[CALLBACK_CLEAR_NEEDS_RESET]);
+    printf("pc_heartbeat: %d\r\n", context->cb_counts[CALLBACK_PC_HEARTBEAT]);
     printf("-----------------------------\r\n");
 
     context->rx = 0.0;

--- a/examples/a300/a300_pc.cpp
+++ b/examples/a300/a300_pc.cpp
@@ -114,6 +114,16 @@ void update_pinout_command()
 }
 
 /**
+ * @brief Updates the PC heartbeat signal.
+ *
+ */
+void update_pc_heartbeat(uint32_t heartbeat_count)
+{
+  node->getBundle("pc_heartbeat").getSignal("heartbeat").setValue<uint32_t>(heartbeat_count);
+  node->sendBundle("pc_heartbeat");
+}
+
+/**
  * @brief Runs the 1 Hz update thread for fans, display, battery, and pinout commands.
  *
  */
@@ -126,6 +136,21 @@ void run_1hz_thread()
     update_battery();
     update_pinout_command();
     std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+}
+
+/**
+ * @brief Runs the 10 Hz update thread for heartbeats
+ *
+ */
+void run_10hz_thread()
+{
+  uint32_t heartbeat_count = 0;
+  while (1)
+  {
+    update_pc_heartbeat(heartbeat_count);
+    heartbeat_count++;
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
 }
 
@@ -175,6 +200,23 @@ void logger_callback(proton::BundleHandle & bundle)
 }
 
 /**
+ * @brief Callback function to handle heartbeat bundle from mcu peer
+ *
+ * @param bundle the bundle containing the heartbeat signal
+ */
+void mcu_heartbeat_callback(proton::BundleHandle & bundle)
+{
+  auto last_heartbeat_time = std::chrono::steady_clock::now();
+  std::stringstream ss;
+  ss << "Received MCU Heartbeat at "
+     << std::chrono::duration_cast<std::chrono::seconds>(last_heartbeat_time.time_since_epoch())
+          .count()
+     << " seconds";
+  ss << " count: " << bundle.getSignal("heartbeat").getValue<uint32_t>();
+  logs.push_back(ss.str());
+}
+
+/**
  * @brief Main function that initializes the node, registers callbacks, starts threads, and runs the
  * node.
  *
@@ -185,9 +227,11 @@ int main()
   node = std::make_unique<proton::Node>(CONFIG_FILE, "pc");
 
   node->registerCallback("log", logger_callback);
+  node->registerCallback("mcu_heartbeat", mcu_heartbeat_callback);
 
   std::thread stats_thread(run_stats_thread);
   std::thread send_1hz_thread(run_1hz_thread);
+  std::thread send_10hz_thread(run_10hz_thread);
   std::thread send_20hz_thread(run_20hz_thread);
 
   node->startStatsThread();
@@ -195,6 +239,7 @@ int main()
 
   stats_thread.join();
   send_1hz_thread.join();
+  send_10hz_thread.join();
   send_20hz_thread.join();
 
   return 0;

--- a/examples/a300/a300_pc.cpp
+++ b/examples/a300/a300_pc.cpp
@@ -200,15 +200,15 @@ void logger_callback(proton::BundleHandle & bundle)
 }
 
 /**
- * @brief Callback function to handle heartbeat bundle from mcu peer
+ * @brief Callback function to handle heartbeat bundle from peer
  *
  * @param bundle the bundle containing the heartbeat signal
  */
-void mcu_heartbeat_callback(proton::BundleHandle & bundle)
+void heartbeat_callback(proton::BundleHandle & bundle)
 {
   auto last_heartbeat_time = std::chrono::steady_clock::now();
   std::stringstream ss;
-  ss << "Received MCU Heartbeat at "
+  ss << "Received " << bundle.getName() << " at "
      << std::chrono::duration_cast<std::chrono::seconds>(last_heartbeat_time.time_since_epoch())
           .count()
      << " seconds";
@@ -227,7 +227,7 @@ int main()
   node = std::make_unique<proton::Node>(CONFIG_FILE, "pc");
 
   node->registerCallback("log", logger_callback);
-  node->registerCallback("mcu_heartbeat", mcu_heartbeat_callback);
+  node->registerCallback("mcu_heartbeat", heartbeat_callback);
 
   std::thread stats_thread(run_stats_thread);
   std::thread send_1hz_thread(run_1hz_thread);

--- a/examples/j100/j100.yaml
+++ b/examples/j100/j100.yaml
@@ -1,16 +1,10 @@
 nodes:
   - name: pc
-    heartbeat:
-      enabled: true
-      period: 1000
     endpoints:
       - id: 0
         type: serial
         device: /tmp/ttyPC
   - name: mcu
-    heartbeat:
-      enabled: true
-      period: 100
     endpoints:
       - id: 0
         type: serial
@@ -21,6 +15,18 @@ connections:
     second: {node: pc, id: 0}
 
 bundles:
+  - name: mcu_heartbeat
+    id: 0x000
+    producers: [mcu]
+    consumers: [pc]
+    signals:
+      - {name: heartbeat, id: 0, type: uint32}
+  - name: pc_heartbeat
+    id: 0x001
+    producers: [pc]
+    consumers: [mcu]
+    signals:
+      - {name: heartbeat, id: 1, type: uint32}
   - name: log
     id: 0x100
     producers: [mcu]

--- a/examples/j100/j100_mcu.c
+++ b/examples/j100/j100_mcu.c
@@ -55,6 +55,7 @@ typedef enum
   CALLBACK_WIFI_CONNECTED,
   CALLBACK_HMI,
   CALLBACK_MOTOR_COMMAND,
+  CALLBACK_PC_HEARTBEAT,
   CALLBACK_COUNT
 } callback_e;
 
@@ -119,6 +120,7 @@ void proton_bundle_pc_heartbeat_callback(void * context)
 {
   context_t * c = (context_t *)context;
   printf("Heartbeat received %u\r\n", c->bundles.pc_heartbeat_bundle.heartbeat);
+  c->cb_counts[CALLBACK_PC_HEARTBEAT]++;
   c->node->peers[PROTON__PEER__PC].state = PROTON_NODE_ACTIVE;
   c->last_pc_heartbeat = time(NULL);
 }
@@ -312,6 +314,17 @@ void update_motor_feedback(void * context)
 }
 
 /**
+ * @brief Updates and sends mcu heartbeat bundle
+ * @param context Pointer to context_t structure
+ */
+void update_mcu_heartbeat(void * context)
+{
+  context_t * c = (context_t *)context;
+  c->bundles.mcu_heartbeat_bundle.heartbeat++;
+  proton_bundle_send(c->node, PROTON__BUNDLE__MCU_HEARTBEAT);
+}
+
+/**
  * @brief Connects PC transport
  * @return PROTON_OK if connection successful, error code otherwise.
  */
@@ -474,7 +487,7 @@ void * timer_1hz(void * arg)
     update_stop_status(context);
     msleep(1000);
 
-    if (time(NULL) - context->last_pc_heartbeat > PROTON__NODE__PC__HEARTBEAT__PERIOD / 1000)
+    if (time(NULL) - context->last_pc_heartbeat > 1)
     {
       context->node->peers[PROTON__PEER__PC].state = PROTON_NODE_INACTIVE;
     }
@@ -503,9 +516,8 @@ void * timer_10hz(void * arg)
     LOG_INFO(context, "10hz timer %ld", i++);
     update_power(context);
     update_temperature(context);
+    update_mcu_heartbeat(context);
 
-    context->bundles.mcu_heartbeat_bundle.heartbeat++;
-    proton_bundle_send(context->node, PROTON_HEARTBEAT_ID);
     msleep(100);
   }
 
@@ -567,6 +579,7 @@ void * stats(void * arg)
     printf("wifi_connected: %d\r\n", context->cb_counts[CALLBACK_WIFI_CONNECTED]);
     printf("hmi: %d\r\n", context->cb_counts[CALLBACK_HMI]);
     printf("motor_command: %d\r\n", context->cb_counts[CALLBACK_MOTOR_COMMAND]);
+    printf("pc_heartbeat: %d\r\n", context->cb_counts[CALLBACK_PC_HEARTBEAT]);
     printf("-----------------------------\r\n");
 
     context->rx = 0.0;

--- a/examples/j100/j100_pc.cpp
+++ b/examples/j100/j100_pc.cpp
@@ -51,6 +51,15 @@ void update_motor_command()
   node->sendBundle("motor_command");
 }
 
+/**
+ * @brief Updates the PC heartbeat signal.
+ */
+void update_pc_heartbeat(uint32_t heartbeat_count)
+{
+  node->getBundle("pc_heartbeat").getSignal("heartbeat").setValue<uint32_t>(heartbeat_count);
+  node->sendBundle("pc_heartbeat");
+}
+
 void run_1hz_thread()
 {
   while (1)
@@ -58,6 +67,20 @@ void run_1hz_thread()
     update_wifi_connected();
     update_hmi();
     std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+}
+
+/**
+ * @brief Runs the 10 Hz update thread for heartbeats
+ */
+void run_10hz_thread()
+{
+  uint32_t heartbeat_count = 0;
+  while (1)
+  {
+    update_pc_heartbeat(heartbeat_count);
+    heartbeat_count++;
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
 }
 
@@ -95,6 +118,23 @@ void logger_callback(proton::BundleHandle & bundle)
   logs.push_back(bundle.getSignal("msg").getValue<std::string>());
 }
 
+/**
+ * @brief Callback function to handle heartbeat bundle from mcu peer
+ *
+ * @param bundle the bundle containing the heartbeat signal
+ */
+void mcu_heartbeat_callback(proton::BundleHandle & bundle)
+{
+  auto last_heartbeat_time = std::chrono::steady_clock::now();
+  std::stringstream ss;
+  ss << "Received MCU Heartbeat at "
+     << std::chrono::duration_cast<std::chrono::seconds>(last_heartbeat_time.time_since_epoch())
+          .count()
+     << " seconds";
+  ss << " count: " << bundle.getSignal("heartbeat").getValue<uint32_t>();
+  logs.push_back(ss.str());
+}
+
 void print_callback(proton::BundleHandle & bundle) { bundle.printBundleVerbose(); }
 
 int main()
@@ -102,9 +142,11 @@ int main()
   node = std::make_unique<proton::Node>(CONFIG_FILE, "pc");
 
   node->registerCallback("log", logger_callback);
+  node->registerCallback("mcu_heartbeat", mcu_heartbeat_callback);
 
   std::thread stats_thread(run_stats_thread);
   std::thread send_1hz_thread(run_1hz_thread);
+  std::thread send_10hz_thread(run_10hz_thread);
   std::thread send_50hz_thread(run_50hz_thread);
 
   node->startStatsThread();
@@ -113,6 +155,7 @@ int main()
 
   stats_thread.join();
   send_1hz_thread.join();
+  send_10hz_thread.join();
   send_50hz_thread.join();
 
   return 0;

--- a/examples/j100/j100_pc.cpp
+++ b/examples/j100/j100_pc.cpp
@@ -119,15 +119,15 @@ void logger_callback(proton::BundleHandle & bundle)
 }
 
 /**
- * @brief Callback function to handle heartbeat bundle from mcu peer
+ * @brief Callback function to handle heartbeat bundle from peer
  *
  * @param bundle the bundle containing the heartbeat signal
  */
-void mcu_heartbeat_callback(proton::BundleHandle & bundle)
+void heartbeat_callback(proton::BundleHandle & bundle)
 {
   auto last_heartbeat_time = std::chrono::steady_clock::now();
   std::stringstream ss;
-  ss << "Received MCU Heartbeat at "
+  ss << "Received " << bundle.getName() << " at "
      << std::chrono::duration_cast<std::chrono::seconds>(last_heartbeat_time.time_since_epoch())
           .count()
      << " seconds";
@@ -142,7 +142,7 @@ int main()
   node = std::make_unique<proton::Node>(CONFIG_FILE, "pc");
 
   node->registerCallback("log", logger_callback);
-  node->registerCallback("mcu_heartbeat", mcu_heartbeat_callback);
+  node->registerCallback("mcu_heartbeat", heartbeat_callback);
 
   std::thread stats_thread(run_stats_thread);
   std::thread send_1hz_thread(run_1hz_thread);

--- a/examples/multi_node/multi_node.yaml
+++ b/examples/multi_node/multi_node.yaml
@@ -1,8 +1,5 @@
 nodes:
   - name: node1
-    heartbeat:
-      enabled: true
-      period: 100
     endpoints:
       - id: 0
         type: udp4
@@ -12,9 +9,6 @@ nodes:
         type: serial
         device: /tmp/ttyNode1
   - name: node2
-    heartbeat:
-      enabled: true
-      period: 1000
     endpoints:
       - id: 0
         type: udp4
@@ -25,9 +19,6 @@ nodes:
         ip: 127.0.0.1
         port: 11418
   - name: node3
-    heartbeat:
-      enabled: true
-      period: 1000
     endpoints:
       - id: 0
         type: serial
@@ -46,6 +37,24 @@ connections:
     second: {node: node3, id: 1}
 
 bundles:
+  - name: node1_heartbeat
+    id: 0x001
+    producers: [node1]
+    consumers: [node2, node3]
+    signals:
+      - {name: heartbeat, id: 1, type: uint32}
+  - name: node2_heartbeat
+    id: 0x002
+    producers: [node2]
+    consumers: [node1, node3]
+    signals:
+      - {name: heartbeat, id: 2, type: uint32}
+  - name: node3_heartbeat
+    id: 0x003
+    producers: [node3]
+    consumers: [node1, node2]
+    signals:
+      - {name: heartbeat, id: 3, type: uint32}
   - name: log
     id: 0x100
     producers: [node1]

--- a/examples/multi_node/multi_node_1.c
+++ b/examples/multi_node/multi_node_1.c
@@ -112,6 +112,17 @@ void proton_bundle_node3_heartbeat_callback(void * context)
 }
 
 /**
+ * @brief Node heartbeat update
+ *
+ * @param context pointer to the context_t structure
+ */
+void send_heartbeat(context_t * context)
+{
+  context->bundles.node1_heartbeat_bundle.heartbeat++;
+  proton_bundle_send(context->node, PROTON__BUNDLE__NODE1_HEARTBEAT);
+}
+
+/**
  * @brief Sends a log message from Node 1
  *
  * @param context Pointer to the context_t structure
@@ -422,12 +433,12 @@ void * timer_1hz(void * arg)
   {
     LOG_INFO(context, "1hz timer %lu", i++);
 
-    if (time(NULL) - context->last_node2_heartbeat > PROTON__NODE__NODE2__HEARTBEAT__PERIOD / 1000)
+    if (time(NULL) - context->last_node2_heartbeat > 1)
     {
       context->node->peers[PROTON__PEER__NODE2].state = PROTON_NODE_INACTIVE;
     }
 
-    if (time(NULL) - context->last_node3_heartbeat > PROTON__NODE__NODE3__HEARTBEAT__PERIOD / 1000)
+    if (time(NULL) - context->last_node3_heartbeat > 1)
     {
       context->node->peers[PROTON__PEER__NODE3].state = PROTON_NODE_INACTIVE;
     }
@@ -451,8 +462,7 @@ void * timer_10hz(void * arg)
   while (1)
   {
     LOG_INFO(context, "10hz timer %lu", i++);
-    proton_bundle_send(context->node, PROTON_HEARTBEAT_ID);
-    context->bundles.node1_heartbeat_bundle.heartbeat++;
+    send_heartbeat(context);
     msleep(100);
   }
   return NULL;

--- a/examples/multi_node/multi_node_1.cpp
+++ b/examples/multi_node/multi_node_1.cpp
@@ -21,10 +21,15 @@
 #include <string.h>
 #include <chrono>
 #include <iostream>
+#include <memory>
+#include <string>
 #include <thread>
+#include <vector>
 #include "protoncpp/proton.hpp"
 
 std::unique_ptr<proton::Node> node;
+
+std::vector<std::string> logs;
 
 void send_log(const char * file, const char * func, int line, uint8_t level, std::string msg, ...);
 
@@ -65,6 +70,13 @@ void send_log(const char * file, const char * func, int line, uint8_t level, std
   node->sendBundle("log");
 }
 
+void send_heartbeat(uint32_t count, const std::string & node_name)
+{
+  auto & heartbeat_signal = node->getBundle(node_name).getSignal("heartbeat");
+  heartbeat_signal.setValue<uint32_t>(count);
+  node->sendBundle(node_name);
+}
+
 void run_1hz_thread()
 {
   uint32_t i = 0;
@@ -80,7 +92,9 @@ void run_10hz_thread()
   uint32_t i = 0;
   while (1)
   {
-    LOG_INFO("Test Log %d", i++);
+    i++;
+    LOG_INFO("Test Log %d", i);
+    send_heartbeat(i, "node1_heartbeat");
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
 }
@@ -90,18 +104,47 @@ void run_stats_thread()
   while (1)
   {
     node->printStats();
+    std::cout << "------------- Logs --------------" << std::endl;
+
+    for (auto & l : logs)
+    {
+      std::cout << l << std::endl;
+    }
+
+    std::cout << "---------------------------------" << std::endl;
+
+    logs.clear();
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }
 }
 
-void empty_callback(proton::BundleHandle & bundle) { bundle.printBundleVerbose(); }
+void print_callback(proton::BundleHandle & bundle) { bundle.printBundleVerbose(); }
+
+/**
+ * @brief Callback function to handle heartbeat bundle from peer
+ *
+ * @param bundle the bundle containing the heartbeat signal
+ */
+void heartbeat_callback(proton::BundleHandle & bundle)
+{
+  auto last_heartbeat_time = std::chrono::steady_clock::now();
+  std::stringstream ss;
+  ss << "Received " << bundle.getName() << " at "
+     << std::chrono::duration_cast<std::chrono::seconds>(last_heartbeat_time.time_since_epoch())
+          .count()
+     << " seconds";
+  ss << " count: " << bundle.getSignal("heartbeat").getValue<uint32_t>();
+  logs.push_back(ss.str());
+}
 
 int main()
 {
   node = std::make_unique<proton::Node>(CONFIG_FILE, "node1");
 
-  node->registerCallback("node_name", empty_callback);
+  node->registerCallback("node_name", print_callback);
+  node->registerCallback("node2_heartbeat", heartbeat_callback);
+  node->registerCallback("node3_heartbeat", heartbeat_callback);
 
   std::thread stats_thread(run_stats_thread);
   std::thread send_1hz_thread(run_1hz_thread);

--- a/examples/multi_node/multi_node_2.c
+++ b/examples/multi_node/multi_node_2.c
@@ -107,6 +107,17 @@ void send_time(context_t * context)
 }
 
 /**
+ * @brief Node heartbeat update
+ *
+ * @param context pointer to the context_t structure
+ */
+void send_heartbeat(context_t * context)
+{
+  context->bundles.node2_heartbeat_bundle.heartbeat++;
+  proton_bundle_send(context->node, PROTON__BUNDLE__NODE2_HEARTBEAT);
+}
+
+/**
  * @brief Log bundle callback handler
  *
  * @param context Pointer to the context_t structure
@@ -399,15 +410,12 @@ void * timer_1hz(void * arg)
   {
     send_node_name(context);
 
-    proton_bundle_send(context->node, PROTON_HEARTBEAT_ID);
-    context->bundles.node2_heartbeat_bundle.heartbeat++;
-
-    if (time(NULL) - context->last_node1_heartbeat > PROTON__NODE__NODE2__HEARTBEAT__PERIOD / 1000)
+    if (time(NULL) - context->last_node1_heartbeat > 1)
     {
       context->node->peers[PROTON__PEER__NODE1].state = PROTON_NODE_INACTIVE;
     }
 
-    if (time(NULL) - context->last_node3_heartbeat > PROTON__NODE__NODE3__HEARTBEAT__PERIOD / 1000)
+    if (time(NULL) - context->last_node3_heartbeat > 1)
     {
       context->node->peers[PROTON__PEER__NODE3].state = PROTON_NODE_INACTIVE;
     }
@@ -432,6 +440,7 @@ void * timer_10hz(void * arg)
   while (1)
   {
     send_time(context);
+    send_heartbeat(context);
     msleep(100);
   }
 

--- a/examples/multi_node/multi_node_2.cpp
+++ b/examples/multi_node/multi_node_2.cpp
@@ -20,12 +20,22 @@
 #include <string.h>
 #include <chrono>
 #include <iostream>
+#include <memory>
+#include <string>
 #include <thread>
+#include <vector>
 #include "protoncpp/proton.hpp"
 
 std::unique_ptr<proton::Node> node;
 
 std::vector<std::string> logs;
+
+void send_heartbeat(uint32_t count, const std::string & node_name)
+{
+  auto & heartbeat_signal = node->getBundle(node_name).getSignal("heartbeat");
+  heartbeat_signal.setValue<uint32_t>(count);
+  node->sendBundle(node_name);
+}
 
 void run_1hz_thread()
 {
@@ -34,6 +44,17 @@ void run_1hz_thread()
     node->getBundle("node_name").getSignal("name").setValue<std::string>(node->getName());
     node->sendBundle("node_name");
     std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+}
+
+void run_10hz_thread()
+{
+  uint32_t heartbeat = 0;
+  while (1)
+  {
+    heartbeat++;
+    send_heartbeat(heartbeat, "node2_heartbeat");
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
 }
 
@@ -73,16 +94,34 @@ void logger_callback(proton::BundleHandle & bundle)
   logs.push_back(bundle.getSignal("msg").getValue<std::string>());
 }
 
-void print_callback(proton::BundleHandle & bundle) { bundle.printBundleVerbose(); }
+/**
+ * @brief Callback function to handle heartbeat bundle from peer
+ *
+ * @param bundle the bundle containing the heartbeat signal
+ */
+void heartbeat_callback(proton::BundleHandle & bundle)
+{
+  auto last_heartbeat_time = std::chrono::steady_clock::now();
+  std::stringstream ss;
+  ss << "Received " << bundle.getName() << " at "
+     << std::chrono::duration_cast<std::chrono::seconds>(last_heartbeat_time.time_since_epoch())
+          .count()
+     << " seconds";
+  ss << " count: " << bundle.getSignal("heartbeat").getValue<uint32_t>();
+  logs.push_back(ss.str());
+}
 
 int main()
 {
   node = std::make_unique<proton::Node>(CONFIG_FILE, "node2");
 
   node->registerCallback("log", logger_callback);
+  node->registerCallback("node1_heartbeat", heartbeat_callback);
+  node->registerCallback("node3_heartbeat", heartbeat_callback);
 
   std::thread stats_thread(run_stats_thread);
   std::thread send_1hz_thread(run_1hz_thread);
+  std::thread send_10hz_thread(run_10hz_thread);
   std::thread send_50hz_thread(run_50hz_thread);
 
   node->startStatsThread();
@@ -91,6 +130,7 @@ int main()
 
   stats_thread.join();
   send_1hz_thread.join();
+  send_10hz_thread.join();
   send_50hz_thread.join();
 
   return 0;

--- a/examples/multi_node/multi_node_3.c
+++ b/examples/multi_node/multi_node_3.c
@@ -88,6 +88,17 @@ void send_node_name(context_t * context)
 }
 
 /**
+ * @brief Node heartbeat update
+ *
+ * @param context pointer to the context_t structure
+ */
+void send_heartbeat(context_t * context)
+{
+  context->bundles.node3_heartbeat_bundle.heartbeat++;
+  proton_bundle_send(context->node, PROTON__BUNDLE__NODE3_HEARTBEAT);
+}
+
+/**
  * @brief Send time bundle
  *
  * @param context Pointer to the context_t structure
@@ -389,19 +400,31 @@ void * timer_1hz(void * arg)
   while (1)
   {
     send_node_name(context);
-    proton_bundle_send(context->node, PROTON_HEARTBEAT_ID);
-    context->bundles.node3_heartbeat_bundle.heartbeat++;
-    if (time(NULL) - context->last_node2_heartbeat > PROTON__NODE__NODE2__HEARTBEAT__PERIOD / 1000)
+    if (time(NULL) - context->last_node2_heartbeat > 1)
     {
       context->node->peers[PROTON__PEER__NODE2].state = PROTON_NODE_INACTIVE;
     }
 
-    if (time(NULL) - context->last_node1_heartbeat > PROTON__NODE__NODE1__HEARTBEAT__PERIOD / 1000)
+    if (time(NULL) - context->last_node1_heartbeat > 1)
     {
       context->node->peers[PROTON__PEER__NODE1].state = PROTON_NODE_INACTIVE;
     }
 
     msleep(1000);
+  }
+
+  return NULL;
+}
+
+void * timer_10hz(void * arg)
+{
+  if (arg == NULL) return NULL;
+  context_t * context = (context_t *)arg;
+
+  while (1)
+  {
+    send_heartbeat(context);
+    msleep(100);
   }
 
   return NULL;
@@ -479,7 +502,7 @@ void * spin_node2(void * arg)
  */
 int main()
 {
-  pthread_t thread_1hz, thread_stats, thread_node2;
+  pthread_t thread_1hz, thread_10hz, thread_stats, thread_node2;
 
   proton_node_t node3_node = PROTON__NODE__NODE3__DEFAULT_VALUE;
   proton_peer_t node3_peers[PROTON__PEER__COUNT] = {
@@ -519,6 +542,7 @@ int main()
   proton_node_node3_init(&node3_node, node3_peers, proton_node3_buffer, &context);
 
   pthread_create(&thread_1hz, NULL, &timer_1hz, &context);
+  pthread_create(&thread_10hz, NULL, &timer_10hz, &context);
   pthread_create(&thread_stats, NULL, &stats, &context);
   pthread_create(&thread_node2, NULL, &spin_node2, &context);
 
@@ -526,6 +550,7 @@ int main()
 
   pthread_join(thread_node2, NULL);
   pthread_join(thread_1hz, NULL);
+  pthread_join(thread_10hz, NULL);
   pthread_join(thread_stats, NULL);
 
   return 0;

--- a/examples/multi_node/multi_node_3.cpp
+++ b/examples/multi_node/multi_node_3.cpp
@@ -20,12 +20,22 @@
 #include <string.h>
 #include <chrono>
 #include <iostream>
+#include <memory>
+#include <string>
 #include <thread>
+#include <vector>
 #include "protoncpp/proton.hpp"
 
 std::unique_ptr<proton::Node> node;
 
 std::vector<std::string> logs;
+
+void send_heartbeat(uint32_t count, const std::string & node_name)
+{
+  auto & heartbeat_signal = node->getBundle(node_name).getSignal("heartbeat");
+  heartbeat_signal.setValue<uint32_t>(count);
+  node->sendBundle(node_name);
+}
 
 void run_1hz_thread()
 {
@@ -34,6 +44,16 @@ void run_1hz_thread()
     node->getBundle("node_name").getSignal("name").setValue<std::string>(node->getName());
     node->sendBundle("node_name");
     std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+}
+
+void run_10hz_thread()
+{
+  uint32_t heartbeat = 0;
+  while (1)
+  {
+    send_heartbeat(heartbeat++, "node3_heartbeat");
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
 }
 
@@ -60,6 +80,23 @@ void logger_callback(proton::BundleHandle & bundle)
   logs.push_back(bundle.getSignal("msg").getValue<std::string>());
 }
 
+/**
+ * @brief Callback function to handle heartbeat bundle from peer
+ *
+ * @param bundle the bundle containing the heartbeat signal
+ */
+void heartbeat_callback(proton::BundleHandle & bundle)
+{
+  auto last_heartbeat_time = std::chrono::steady_clock::now();
+  std::stringstream ss;
+  ss << "Received " << bundle.getName() << " at "
+     << std::chrono::duration_cast<std::chrono::seconds>(last_heartbeat_time.time_since_epoch())
+          .count()
+     << " seconds";
+  ss << " count: " << bundle.getSignal("heartbeat").getValue<uint32_t>();
+  logs.push_back(ss.str());
+}
+
 int main()
 {
   node = std::make_unique<proton::Node>(CONFIG_FILE, "node3");
@@ -67,15 +104,19 @@ int main()
   std::cout << "Init" << std::endl;
 
   node->registerCallback("log", logger_callback);
+  node->registerCallback("node1_heartbeat", heartbeat_callback);
+  node->registerCallback("node2_heartbeat", heartbeat_callback);
 
   std::thread stats_thread(run_stats_thread);
   std::thread send_1hz_thread(run_1hz_thread);
+  std::thread send_10hz_thread(run_10hz_thread);
 
   node->startStatsThread();
   node->spin();
 
   stats_thread.join();
   send_1hz_thread.join();
+  send_10hz_thread.join();
 
   return 0;
 }

--- a/generator_scripts/generator.py
+++ b/generator_scripts/generator.py
@@ -25,7 +25,6 @@ from pathlib import Path
 from config import validate_ids
 from jinja2 import Template
 from normalize import (
-    set_heartbeat_producers_consumers,
     set_node_endpoint_address,
     set_signal_properties,
 )
@@ -152,7 +151,6 @@ def main():
     # validate node config here
     validate_ids(config['bundles'])
     set_node_endpoint_address(config['nodes'])
-    set_heartbeat_producers_consumers(config['nodes'], config['connections'])
     set_signal_properties(config['bundles'])
 
     generate_header(dest_path, config, name, target)

--- a/generator_scripts/generator.py
+++ b/generator_scripts/generator.py
@@ -25,7 +25,6 @@ from pathlib import Path
 from config import validate_ids
 from jinja2 import Template
 from normalize import (
-    normalize_node_heartbeats,
     set_heartbeat_producers_consumers,
     set_node_endpoint_address,
     set_signal_properties,
@@ -153,7 +152,6 @@ def main():
     # validate node config here
     validate_ids(config['bundles'])
     set_node_endpoint_address(config['nodes'])
-    normalize_node_heartbeats(config['nodes'])
     set_heartbeat_producers_consumers(config['nodes'], config['connections'])
     set_signal_properties(config['bundles'])
 

--- a/generator_scripts/normalize.py
+++ b/generator_scripts/normalize.py
@@ -103,27 +103,6 @@ def set_node_endpoint_address(nodes: list[dict]):
                 endpoint['ipnl'] = ip_nl
 
 
-def set_heartbeat_producers_consumers(nodes: list[dict], connections: list[dict]):
-    """
-    Determine which heartbeats go where.
-
-    Args:
-        nodes: "nodes" stanza in proton config
-        connections: "connections" stanza in proton config
-
-    """
-    for node in nodes:
-        if node.get('heartbeat') is not None and node['heartbeat']['enabled']:
-            node['heartbeat']['producers'] = node['name']
-            for connection in connections:
-                if node['heartbeat'].get('consumers') is None:
-                    node['heartbeat']['consumers'] = []
-                if connection['first']['node'] == node['name']:
-                    node['heartbeat']['consumers'].append(connection['second']['node'])
-                if connection['second']['node'] == node['name']:
-                    node['heartbeat']['consumers'].append(connection['first']['node'])
-
-
 def set_signal_properties(bundles: list[dict]):
     """
     Set properties for signals. Default values, repeated type lengths, const-ness.

--- a/generator_scripts/normalize.py
+++ b/generator_scripts/normalize.py
@@ -21,20 +21,6 @@ from config import validate_signal_elements
 from internal_types import DEFAULT_VALUE_MAP, INTERNAL_TYPE_MAP
 
 
-def normalize_node_heartbeats(nodes: list[dict]):
-    """
-    Normalize the configuration for whether or not heartbeats are present.
-
-    Args:
-        nodes: "nodes" stanza in proton config
-
-    """
-    default_heartbeat = {'enabled': False, 'period': 0}
-
-    for node in nodes:
-        node.setdefault('heartbeat', default_heartbeat)
-
-
 def normalize_signals(bundle: dict):
     """
     Normalize signal configuration for optional node elements.

--- a/generator_scripts/resources/proton__header_node.h.jinja
+++ b/generator_scripts/resources/proton__header_node.h.jinja
@@ -43,9 +43,6 @@ extern "C" {
 {% else %}
 #define PROTON__NODE__{{ node_name }}__DEFAULT_VALUE PROTON_NODE_DEFAULT(PROTON__NODE__{{ node_name }}__NAME)
 {% endif %}
-#define PROTON__NODE__{{ node_name }}__HEARTBEAT__ENABLED {{ node.heartbeat.enabled | lower }}
-#define PROTON__NODE__{{ node_name }}__HEARTBEAT__PERIOD {{ node.heartbeat.period }}
-#define PROTON__NODE__{{ node_name }}__HEARTBEAT__DEFAULT_VALUE {PROTON__NODE__{{ node_name }}__HEARTBEAT__ENABLED, PROTON__NODE__{{ node_name }}__HEARTBEAT__PERIOD}
 {% for endpoint in node.endpoints %}
 #define PROTON__NODE__{{ node_name }}__ENDPOINT__{{ endpoint_ns.count }}__ID {{ endpoint.id }}
 #define PROTON__NODE__{{ node_name }}__ENDPOINT__{{ endpoint_ns.count }}__TYPE "{{ endpoint.type }}"
@@ -81,16 +78,6 @@ typedef enum PROTON__BUNDLE__{{ bundle_name }}__SIGNAL {
 {% endif %}
 {% endfor %}
 
-{% for node in nodes %}
-{% if node.heartbeat.enabled %}
-{% set heartbeat_name = "PROTON__BUNDLE__" + node.name | upper + "_HEARTBEAT__SIGNAL" %}
-typedef enum {{ heartbeat_name }} {
-  {{ heartbeat_name }}__HEARTBEAT,
-  {{ heartbeat_name }}__COUNT
-} {{ heartbeat_name }}_e;
-{% endif %}
-{% endfor %}
-
 // Constant definitions
 
 {% for bundle in bundles %}
@@ -117,17 +104,7 @@ typedef enum {{ heartbeat_name }} {
 #define {{ bundle_name }}__CONSUMERS ({% for consumer in bundle.consumers %}PROTON__NODE__{{ consumer | upper }}__ID{% if not loop.last %} | {% endif %}{% endfor %})
 {% endfor %}
 
-{% for node in nodes %}
-{% if node.heartbeat.enabled %}
-{% set heartbeat_name = node.name | upper + "_HEARTBEAT"%}
-#define PROTON__BUNDLE__{{ heartbeat_name }}__SIGNAL__HEARTBEAT__DEFAULT_VALUE 0
-#define PROTON__BUNDLE__{{ heartbeat_name }}__DEFAULT_VALUE {PROTON__BUNDLE__{{ heartbeat_name }}__SIGNAL__HEARTBEAT__DEFAULT_VALUE}
-#define PROTON__BUNDLE__{{ heartbeat_name }}__PRODUCERS (PROTON__NODE__{{ node.name | upper }}__ID)
-#define PROTON__BUNDLE__{{ heartbeat_name }}__CONSUMERS ({% for consumer in node.heartbeat.consumers %}PROTON__NODE__{{ consumer | upper }}__ID{% if not loop.last %} | {% endif %}{% endfor %})
-{% endif %}
-{% endfor %}
-
-#define PROTON__BUNDLES__{{ target | upper }}__DEFAULT_VALUE { {% for bundle in bundles %}{% if bundle.signals is defined %}PROTON__BUNDLE__{{ bundle.name | upper }}__DEFAULT_VALUE, {% endif %}{% endfor %}{% for node in nodes %}{% if node.heartbeat.enabled %}PROTON__BUNDLE__{{ node.name | upper }}_HEARTBEAT__DEFAULT_VALUE{% if not loop.last %}, {% endif %}{% endif %} {% endfor %} }
+#define PROTON__BUNDLES__{{ target | upper }}__DEFAULT_VALUE { {% for bundle in bundles %}{% if bundle.signals is defined %}PROTON__BUNDLE__{{ bundle.name | upper }}__DEFAULT_VALUE{% if not loop.last %}, {% endif %}{% endif %}{% endfor %} }
 
 // Bundle Structure Definitions
 {% for bundle in bundles %}
@@ -150,21 +127,11 @@ typedef struct proton_bundles_{{ target }} {
 {% for bundle in bundles %}
 {% if bundle.signals is defined %}  proton_bundle_{{ bundle.name }}_t {{ bundle.name}}_bundle;{% endif %}
 {% endfor %}
-{% for node in nodes %}
-{% if node.heartbeat.enabled %}
-  proton_bundle_heartbeat_t {{ node.name }}_heartbeat_bundle;
-{% endif %}
-{% endfor %}
 } proton_bundles_{{ target }}_t;
 
 // Bundle Init Prototype
 {% for bundle in bundles %}
 proton_status_e proton_bundle_{{ bundle.name }}_init({% if bundle.signals is defined %}proton_bundle_{{ bundle.name }}_t * bundle{% endif %});
-{% endfor %}
-{% for node in nodes %}
-{% if node.heartbeat.enabled %}
-proton_status_e proton_bundle_{{ node.name }}_heartbeat_init(proton_bundle_heartbeat_t * bundle);
-{% endif %}
 {% endfor %}
 
 proton_status_e proton_bundles_{{ target }}_init(proton_bundles_{{ target }}_t * bundles);
@@ -209,10 +176,6 @@ proton_status_e proton_bundle_send(proton_node_t * node, uint32_t id);
 
 {% for bundle in bundles %}
 {% if target in bundle.consumers %}void proton_bundle_{{ bundle.name }}_callback(void * context);{% endif %}
-{% endfor %}
-
-{% for node in nodes %}
-{% if node.name != target and node.heartbeat.enabled %}void proton_bundle_{{ node.name }}_heartbeat_callback(void * context);{% endif %}
 {% endfor %}
 
 // Transport Prototypes

--- a/generator_scripts/resources/proton__source_node.c.jinja
+++ b/generator_scripts/resources/proton__source_node.c.jinja
@@ -23,20 +23,10 @@
 {% for bundle in bundles %}
 {% if bundle.signals is defined %}static proton_signal_handle_t _{{ bundle.name }}_signal_handles[PROTON__BUNDLE__{{ bundle.name | upper }}__SIGNAL__COUNT];{% endif %}
 {% endfor %}
-{% for node in nodes %}
-{% if node.heartbeat.enabled %}
-static proton_signal_handle_t _{{ node.name }}_heartbeat_signal_handles[PROTON__BUNDLE__{{ node.name | upper }}_HEARTBEAT__SIGNAL__COUNT];
-{% endif %}
-{% endfor %}
 
 // Internal Bundles
 {% for bundle in bundles %}
 static proton_bundle_handle_t _{{ bundle.name }}_bundle_handle;
-{% endfor %}
-{% for node in nodes %}
-{% if node.heartbeat.enabled %}
-static proton_bundle_handle_t _{{ node.name }}_heartbeat_bundle_handle;
-{% endif %}
 {% endfor %}
 
 // Bundle Init Functions
@@ -68,33 +58,6 @@ proton_status_e proton_bundle_{{ bundle.name }}_init({% if bundle.signals is def
 }
 {% endfor %}
 
-{% for node in nodes %}
-{% if node.heartbeat.enabled %}
-proton_status_e proton_bundle_{{ node.name }}_heartbeat_init(proton_bundle_heartbeat_t * bundle)
-{
-  proton_status_e status;
-  status = proton_init_signal(
-    &_{{ node.name }}_heartbeat_signal_handles[PROTON__BUNDLE__{{ node.name | upper }}_HEARTBEAT__SIGNAL__HEARTBEAT],
-    proton_Signal_uint32_value_tag,
-    &bundle->heartbeat,
-    0
-  );
-  if (status != PROTON_OK)
-  {
-    return status;
-  }
-  return proton_init_bundle(
-    &_{{ node.name }}_heartbeat_bundle_handle,
-    PROTON_HEARTBEAT_ID,
-    _{{ node.name }}_heartbeat_signal_handles,
-    PROTON__BUNDLE__{{ node.name | upper }}_HEARTBEAT__SIGNAL__COUNT,
-    PROTON__BUNDLE__{{ node.name | upper }}_HEARTBEAT__PRODUCERS,
-    PROTON__BUNDLE__{{ node.name | upper }}_HEARTBEAT__CONSUMERS
-  );
-}
-{% endif %}
-{% endfor %}
-
 proton_status_e proton_bundles_{{ target }}_init(proton_bundles_{{ target }}_t * bundles)
 {
   proton_status_e status;
@@ -105,15 +68,6 @@ proton_status_e proton_bundles_{{ target }}_init(proton_bundles_{{ target }}_t *
   {
     return status;
   }
-{% endfor %}
-{% for node in nodes %}
-{% if node.heartbeat.enabled %}
-  status = proton_bundle_{{ node.name }}_heartbeat_init(&bundles->{{ node.name }}_heartbeat_bundle);
-  if (status != PROTON_OK)
-  {
-    return status;
-  }
-{% endif %}
 {% endfor %}
 
   return PROTON_OK;
@@ -148,30 +102,6 @@ proton_status_e proton_bundle_decode(proton_buffer_t buffer, proton_producer_t p
       break;
     }
 {% endfor %}
-
-    case PROTON_HEARTBEAT_ID:
-    {
-      switch (producer)
-      {
-{% for node in nodes %}
-{% if node.heartbeat.enabled %}
-        case PROTON__NODE__{{ node.name | upper }}__ID:
-        {
-          handle = &_{{ node.name }}_heartbeat_bundle_handle;
-          break;
-        }
-{% endif %}
-{% endfor %}
-
-        default:
-        {
-          return PROTON_ERROR;
-        }
-      }
-
-      break;
-    }
-
     default:
     {
       return PROTON_ERROR;
@@ -214,16 +144,6 @@ proton_status_e proton_bundle_encode(proton_buffer_t buffer, uint32_t id, size_t
     case PROTON__BUNDLE__{{ bundle.name | upper }}:
     {
       handle = &_{{ bundle.name }}_bundle_handle;
-      break;
-    }
-{% endif %}
-{% endfor %}
-
-{% for node in nodes %}
-{% if node.name == target and node.heartbeat.enabled %}
-    case PROTON_HEARTBEAT_ID:
-    {
-      handle = &_{{ target }}_heartbeat_bundle_handle;
       break;
     }
 {% endif %}
@@ -303,14 +223,6 @@ proton_status_e proton_node_{{ node.name }}_receive(proton_node_t * node, size_t
     }
 {% endif %}
 {% endfor %}
-
-{% if node.heartbeat.enabled %}
-    case PROTON_HEARTBEAT_ID:
-    {
-      callback = proton_bundle_{{ node.name }}_heartbeat_callback;
-      break;
-    }
-{% endif %}
     default:
     {
       return PROTON_ERROR;
@@ -370,16 +282,6 @@ proton_status_e proton_bundle_send(proton_node_t * node, uint32_t id)
     }
 {% endif %}
 {% endfor %}
-
-{% for node in nodes %}
-{% if node.name == target and node.heartbeat.enabled %}
-    case PROTON_HEARTBEAT_ID:
-    {
-      handle = &_{{ target }}_heartbeat_bundle_handle;
-      break;
-    }
-{% endif %}
-{% endfor %}
     default:
     {
       return PROTON_ERROR;
@@ -425,15 +327,6 @@ __attribute__((weak)) void proton_bundle_{{ bundle.name }}_callback(void * conte
 {% endif %}
 {% endfor %}
 
-{% for node in nodes %}
-{% if node.name != target and node.heartbeat.enabled %}
-__attribute__((weak)) void proton_bundle_{{ node.name }}_heartbeat_callback(void * context)
-{
-  (void)context;
-}
-{% endif %}
-{% endfor %}
-
 // Weak Mutex functions
 
 {% for node in nodes %}
@@ -455,7 +348,6 @@ proton_status_e proton_peer_{{ node.name }}_init(proton_peer_t * peer, proton_bu
   return proton_init_peer(
     peer,
     {{ node_name }}ID,
-    (proton_heartbeat_t){{ node_name }}HEARTBEAT__DEFAULT_VALUE,
     (proton_transport_t){{ node_name }}TRANSPORT__DEFAULT_VALUE,
     proton_node_{{ node.name }}_receive,
     proton_node_{{ node.name }}_lock,
@@ -479,7 +371,6 @@ proton_status_e proton_node_{{ target }}_init(proton_node_t * node, proton_peer_
 
   status = proton_configure(
     node,
-    (proton_heartbeat_t)PROTON__NODE__{{ target | upper }}__HEARTBEAT__DEFAULT_VALUE,
     proton_node_{{ target }}_lock,
     proton_node_{{ target }}_unlock,
     buffer,

--- a/include/proton/common.h
+++ b/include/proton/common.h
@@ -29,9 +29,6 @@ extern "C"
 // Max message size
 #define PROTON_MAX_MESSAGE_SIZE UINT16_MAX
 
-// Heartbeat bundle ID
-#define PROTON_HEARTBEAT_ID 0
-
 // Serial Framing
 // [0x50][0x52][Length byte 0][Length byte 1][Payload][CRC16 byte 0][CRC16 byte 1]
 #define PROTON_FRAME_HEADER_MAGIC_BYTE_0 \

--- a/protonc/include/protonc/node.h
+++ b/protonc/include/protonc/node.h
@@ -53,17 +53,10 @@ typedef struct
   proton_transport_write_t write;
 } proton_transport_t;
 
-typedef struct
-{
-  bool enabled;
-  uint32_t period;
-} proton_heartbeat_t;
-
 typedef struct proton_peer
 {
   proton_node_state_e state;
   proton_peer_id_t id;
-  proton_heartbeat_t heartbeat;
   proton_transport_t transport;
   proton_receive_t receive;
   proton_atomic_buffer_t atomic_buffer;
@@ -73,7 +66,6 @@ typedef struct proton_peer
 typedef struct proton_node
 {
   proton_node_state_e state;
-  proton_heartbeat_t heartbeat;
   proton_atomic_buffer_t atomic_buffer;
   uint16_t peer_count;
   proton_peer_t * peers;
@@ -82,39 +74,26 @@ typedef struct proton_node
 } proton_node_t;
 
 #define PROTON_TRANSPORT_DEFAULT_VALUE {PROTON_TRANSPORT_DISCONNECTED, NULL, NULL, NULL, NULL}
-#define PROTON_HEARTBEAT_DEFAULT_VALUE {false, 0}
 #define PROTON_ATOMIC_BUFFER_DEFAULT_VALUE {PROTON_BUFFER_DEFAULT_VALUE, NULL, NULL}
 
-#define PROTON_PEER_DEFAULT(name)      \
-  {PROTON_NODE_UNCONFIGURED,           \
-   0,                                  \
-   PROTON_HEARTBEAT_DEFAULT_VALUE,     \
-   PROTON_TRANSPORT_DEFAULT_VALUE,     \
-   NULL,                               \
-   PROTON_ATOMIC_BUFFER_DEFAULT_VALUE, \
-   name}
-#define PROTON_NODE_DEFAULT(name)      \
-  {PROTON_NODE_UNCONFIGURED,           \
-   PROTON_HEARTBEAT_DEFAULT_VALUE,     \
-   PROTON_ATOMIC_BUFFER_DEFAULT_VALUE, \
-   0,                                  \
-   NULL,                               \
-   name,                               \
-   NULL}
+#define PROTON_PEER_DEFAULT(name)                                                 \
+  {PROTON_NODE_UNCONFIGURED,           0,   PROTON_TRANSPORT_DEFAULT_VALUE, NULL, \
+   PROTON_ATOMIC_BUFFER_DEFAULT_VALUE, name}
+#define PROTON_NODE_DEFAULT(name) \
+  {PROTON_NODE_UNCONFIGURED, PROTON_ATOMIC_BUFFER_DEFAULT_VALUE, 0, NULL, name, NULL}
 
 #define TRANSPORT_VALID(transport)                                                        \
   (transport.connect != NULL && transport.disconnect != NULL && transport.read != NULL && \
    transport.write != NULL)
 
 proton_status_e proton_init_peer(
-  proton_peer_t * peer, proton_peer_id_t id, proton_heartbeat_t heartbeat,
-  proton_transport_t transport, proton_receive_t receive_func, proton_mutex_lock_t lock_func,
-  proton_mutex_unlock_t unlock_func, proton_buffer_t read_buf);
+  proton_peer_t * peer, proton_peer_id_t id, proton_transport_t transport,
+  proton_receive_t receive_func, proton_mutex_lock_t lock_func, proton_mutex_unlock_t unlock_func,
+  proton_buffer_t read_buf);
 
 proton_status_e proton_configure(
-  proton_node_t * node, proton_heartbeat_t heartbeat, proton_mutex_lock_t lock_func,
-  proton_mutex_unlock_t unlock_func, proton_buffer_t write_buf, proton_peer_t * peers,
-  uint16_t peer_count, void * context);
+  proton_node_t * node, proton_mutex_lock_t lock_func, proton_mutex_unlock_t unlock_func,
+  proton_buffer_t write_buf, proton_peer_t * peers, uint16_t peer_count, void * context);
 
 proton_status_e proton_activate(proton_node_t * node);
 

--- a/protonc/include/protonc/proton.h
+++ b/protonc/include/protonc/proton.h
@@ -56,14 +56,8 @@ typedef struct
   size_t len;
 } proton_buffer_t;
 
-typedef struct proton_bundle_heartbeat
-{
-  uint32_t heartbeat;
-} proton_bundle_heartbeat_t;
-
 #define PROTON_LIST_ARG_DEFAULT_VALUE {NULL, 0, 0, 0}
 #define PROTON_BUFFER_DEFAULT_VALUE {NULL, 0}
-#define PROTON_HEARTBEAT_BUNDLE_DEFAULT_VALUE {0}
 
 proton_status_e proton_init_signal(
   proton_signal_handle_t * handle, pb_size_t which_signal, void * data, size_t capacity);

--- a/protonc/src/node.c
+++ b/protonc/src/node.c
@@ -25,7 +25,6 @@
  *
  * @param peer Peer to initialize
  * @param id Peer ID
- * @param heartbeat Heartbeat configuration
  * @param transport Transport configuration
  * @param receive_func Receive function
  * @param lock_func Lock function
@@ -34,19 +33,13 @@
  * @return proton_status_e Initialization status
  */
 proton_status_e proton_init_peer(
-  proton_peer_t * peer, proton_peer_id_t id, proton_heartbeat_t heartbeat,
-  proton_transport_t transport, proton_receive_t receive_func, proton_mutex_lock_t lock_func,
-  proton_mutex_unlock_t unlock_func, proton_buffer_t buffer)
+  proton_peer_t * peer, proton_peer_id_t id, proton_transport_t transport,
+  proton_receive_t receive_func, proton_mutex_lock_t lock_func, proton_mutex_unlock_t unlock_func,
+  proton_buffer_t buffer)
 {
   if (peer && TRANSPORT_VALID(transport) && receive_func && lock_func && unlock_func && buffer.data)
   {
-    if (heartbeat.enabled && heartbeat.period == 0)
-    {
-      return PROTON_ERROR;
-    }
-
     peer->id = id;
-    peer->heartbeat = heartbeat;
     peer->transport = transport;
     peer->receive = receive_func;
     peer->atomic_buffer.lock = lock_func;
@@ -64,7 +57,6 @@ proton_status_e proton_init_peer(
  * @brief Configure a Proton node.
  *
  * @param node Node to configure
- * @param heartbeat Heartbeat configuration
  * @param lock_func Lock function
  * @param unlock_func Unlock function
  * @param buffer Write buffer
@@ -74,15 +66,13 @@ proton_status_e proton_init_peer(
  * @return proton_status_e Configuration status
  */
 proton_status_e proton_configure(
-  proton_node_t * node, proton_heartbeat_t heartbeat, proton_mutex_lock_t lock_func,
-  proton_mutex_unlock_t unlock_func, proton_buffer_t buffer, proton_peer_t * peers,
-  uint16_t peer_count, void * context)
+  proton_node_t * node, proton_mutex_lock_t lock_func, proton_mutex_unlock_t unlock_func,
+  proton_buffer_t buffer, proton_peer_t * peers, uint16_t peer_count, void * context)
 {
   if (node && lock_func && unlock_func && buffer.data && peers && peer_count > 0)
   {
     node->peer_count = peer_count;
     node->peers = peers;
-    node->heartbeat = heartbeat;
     node->atomic_buffer.buffer = buffer;
     node->atomic_buffer.lock = lock_func;
     node->atomic_buffer.unlock = unlock_func;

--- a/protoncpp/include/protoncpp/bundle_manager.hpp
+++ b/protoncpp/include/protoncpp/bundle_manager.hpp
@@ -31,9 +31,7 @@ class BundleManager
 {
 public:
   void addBundle(BundleConfig config);
-  void addHeartbeat(std::string producer, std::vector<std::string> consumers);
   BundleHandle & getBundle(const std::string & bundle_name);
-  BundleHandle & getHeartbeat(const std::string & producer);
   std::map<std::string, BundleHandle> & getBundleMap();
   std::optional<std::string> updateBundle(const Bundle & bundle, const std::string & producer);
 
@@ -43,9 +41,7 @@ public:
 protected:
   std::vector<std::string> nodes_;
   std::map<std::string, BundleHandle> bundles_;
-  std::map<std::string, BundleHandle> heartbeat_bundles_;
   std::shared_mutex bundle_mutex_;
-  std::shared_mutex heartbeat_mutex_;
 };
 
 }  // namespace proton

--- a/protoncpp/include/protoncpp/config.hpp
+++ b/protoncpp/include/protoncpp/config.hpp
@@ -37,7 +37,6 @@ namespace keys
 static const char * const NODES = "nodes";
 static const char * const BUNDLES = "bundles";
 static const char * const NAME = "name";
-static const char * const HEARTBEAT = "heartbeat";
 static const char * const ENABLED = "enabled";
 static const char * const PERIOD = "period";
 static const char * const ENDPOINTS = "endpoints";
@@ -117,16 +116,9 @@ struct EndpointConfig
   uint32_t port;
 };
 
-struct HeartbeatConfig
-{
-  bool enabled;
-  uint32_t period;
-};
-
 struct NodeConfig
 {
   std::string name;
-  HeartbeatConfig heartbeat;
   std::map<uint32_t, EndpointConfig> endpoints;
 };
 

--- a/protoncpp/include/protoncpp/proton.hpp
+++ b/protoncpp/include/protoncpp/proton.hpp
@@ -112,7 +112,6 @@ public:
     const ConnectionConfig & connection_config, ReadCompleteCallback callback);
 
   void run();
-  void heartbeat();
   NodeConfig getConfig() { return config_; }
   proton_node_state_e getNodeState() { return state_; }
   std::string getTransportType() { return transport_type_; }
@@ -122,15 +121,13 @@ public:
 
 private:
   void spin();
-  void checkHeartbeat();
   proton_status_e pollForBundle();
 
   NodeConfig config_;
   std::string transport_type_;
   ReadCompleteCallback callback_;
-  std::thread run_thread_, heartbeat_thread_;
+  std::thread run_thread_;
   proton_node_state_e state_;
-  int64_t last_heartbeat_ms_;
   double rx_kbps_, tx_kbps_;
 };
 
@@ -158,13 +155,9 @@ public:
 
   proton_status_e sendBundle(const std::string & bundle_name);
   proton_status_e sendBundle(BundleHandle & bundle_handle);
-  proton_status_e sendHeartbeat();
 
   proton_status_e registerCallback(
     const std::string & bundle_name, BundleHandle::BundleCallback callback);
-  proton_status_e registerHeartbeatCallback(
-    const std::string & producer, BundleHandle::BundleCallback callback);
-
   std::string getName() const { return name_; }
   NodeConfig getNodeConfig() const { return node_config_; }
   Config & getConfig() { return config_; }
@@ -175,7 +168,6 @@ public:
 
 private:
   void runStatsThread();
-  void runHeartbeatThread();
 
   Config config_;
   NodeConfig node_config_;
@@ -186,7 +178,7 @@ private:
   SafeQueue<ReceivedBundle> read_queue_;
 
   // Stats
-  std::thread stats_thread_, heartbeat_thread_;
+  std::thread stats_thread_;
 };
 
 }  // namespace proton

--- a/protoncpp/src/bundle_manager.cpp
+++ b/protoncpp/src/bundle_manager.cpp
@@ -29,24 +29,6 @@ void BundleManager::addBundle(BundleConfig config)
   bundles_.emplace(config.name, BundleHandle(config));
 }
 
-void BundleManager::addHeartbeat(std::string producer, std::vector<std::string> consumers)
-{
-  SignalConfig signal_config = {
-    .name = "heartbeat",
-    .type_string = std::string(value_types::UINT32.begin(), value_types::UINT32.end()),
-    .has_default_value = false};
-
-  BundleConfig config = {
-    .name = producer,
-    .id = 0,
-    .producers = {producer},
-    .consumers = consumers,
-    .signals = std::vector<SignalConfig>({signal_config})};
-
-  std::unique_lock lock(heartbeat_mutex_);
-  heartbeat_bundles_.emplace(config.name, BundleHandle(config));
-}
-
 BundleHandle & BundleManager::getBundle(const std::string & bundle_name)
 {
   std::shared_lock lock(bundle_mutex_);
@@ -56,27 +38,7 @@ BundleHandle & BundleManager::getBundle(const std::string & bundle_name)
   }
   catch (std::out_of_range & e)
   {
-    try
-    {
-      return heartbeat_bundles_.at(bundle_name);
-    }
-    catch (std::out_of_range & e)
-    {
-      throw std::runtime_error("Invalid bundle name " + bundle_name);
-    }
-  }
-}
-
-BundleHandle & BundleManager::getHeartbeat(const std::string & producer)
-{
-  std::shared_lock lock(heartbeat_mutex_);
-  try
-  {
-    return heartbeat_bundles_.at(producer);
-  }
-  catch (std::out_of_range & e)
-  {
-    throw std::runtime_error("Invalid producer " + producer);
+    throw std::runtime_error("Invalid bundle name " + bundle_name);
   }
 }
 
@@ -89,38 +51,13 @@ std::map<std::string, BundleHandle> & BundleManager::getBundleMap()
 std::optional<std::string> BundleManager::updateBundle(
   const Bundle & bundle, const std::string & producer)
 {
-  // Heartbeat bundles have an id of 0
-  if (bundle.id() == 0)
+  for (auto & [name, handle] : bundles_)
   {
-    // Heartbeat should have just one uint32_t signal
-    if (bundle.signals_size() == 1 && bundle.signals(0).has_uint32_value())
+    if (handle.getId() == bundle.id())
     {
-      for (auto & [name, handle] : heartbeat_bundles_)
-      {
-        if (handle.getName() == producer)
-        {
-          std::unique_lock lock(heartbeat_mutex_);
-          handle.updateBundle(bundle);
-          return handle.getName();
-        }
-      }
-    }
-    else
-    {
-      std::cerr << "Invalid heartbeat received" << std::endl;
-      return std::nullopt;
-    }
-  }
-  else
-  {
-    for (auto & [name, handle] : bundles_)
-    {
-      if (handle.getId() == bundle.id())
-      {
-        std::unique_lock lock(bundle_mutex_);
-        handle.updateBundle(bundle);
-        return handle.getName();
-      }
+      std::unique_lock lock(bundle_mutex_);
+      handle.updateBundle(bundle);
+      return handle.getName();
     }
   }
 

--- a/protoncpp/src/config.cpp
+++ b/protoncpp/src/config.cpp
@@ -179,38 +179,6 @@ struct convert<proton::EndpointConfig>
 };
 
 template <>
-struct convert<proton::HeartbeatConfig>
-{
-  static bool decode(const Node & node, proton::HeartbeatConfig & rhs)
-  {
-    if (!node.IsDefined() || node.IsNull())
-    {
-      return false;
-    }
-
-    if (node[proton::keys::ENABLED])
-    {
-      rhs.enabled = node[proton::keys::ENABLED].as<bool>();
-    }
-    else
-    {
-      rhs.enabled = false;
-    }
-
-    if (node[proton::keys::PERIOD])
-    {
-      rhs.period = node[proton::keys::PERIOD].as<uint32_t>();
-    }
-    else
-    {
-      rhs.period = 1000;
-    }
-
-    return true;
-  }
-};
-
-template <>
 struct convert<proton::NodeConfig>
 {
   static bool decode(const Node & node, proton::NodeConfig & rhs)
@@ -234,16 +202,6 @@ struct convert<proton::NodeConfig>
 
         rhs.endpoints.emplace(id, endpoint.as<proton::EndpointConfig>());
       }
-    }
-
-    if (node[proton::keys::HEARTBEAT])
-    {
-      rhs.heartbeat = node[proton::keys::HEARTBEAT].as<proton::HeartbeatConfig>();
-    }
-    else
-    {
-      rhs.heartbeat.enabled = false;
-      rhs.heartbeat.period = 0;
     }
 
     return true;

--- a/protoncpp/src/config.cpp
+++ b/protoncpp/src/config.cpp
@@ -124,10 +124,6 @@ struct convert<proton::BundleConfig>
     }
 
     rhs.id = node[proton::keys::ID].as<uint32_t>();
-    if (rhs.id == 0U)
-    {
-      throw std::runtime_error("Bundle ID cannot be 0");
-    }
 
     YAML::Node signals = node[proton::keys::SIGNALS];
 

--- a/protoncpp/src/proton.cpp
+++ b/protoncpp/src/proton.cpp
@@ -99,21 +99,6 @@ proton_status_e Node::configure()
                 &Node::readCompleteCallback, this, std::placeholders::_1, std::placeholders::_2)));
   }
 
-  if (node_config_.heartbeat.enabled)
-  {
-    // Add a heartbeat bundle to send to each peer
-    addHeartbeat(name_, peers_);
-  }
-
-  for (auto & [peer_name, peer] : connections_)
-  {
-    // Add a heartbeat bundle to receive from each peer
-    if (peer.getConfig().heartbeat.enabled)
-    {
-      addHeartbeat(peer_name, {name_});
-    }
-  }
-
   state_ = PROTON_NODE_INACTIVE;
   return PROTON_OK;
 }
@@ -128,12 +113,6 @@ proton_status_e Node::activate()
   for (auto & [name, peer] : connections_)
   {
     peer.run();
-  }
-
-  // Start heartbeat thread
-  if (node_config_.heartbeat.enabled)
-  {
-    heartbeat_thread_ = std::thread(&Node::runHeartbeatThread, this);
   }
 
   state_ = PROTON_NODE_ACTIVE;
@@ -180,44 +159,10 @@ proton_status_e Node::sendBundle(BundleHandle & bundle_handle)
   return PROTON_SERIALIZATION_ERROR;
 }
 
-proton_status_e Node::sendHeartbeat()
-{
-  if (!node_config_.heartbeat.enabled)
-  {
-    return PROTON_ERROR;
-  }
-
-  auto & heartbeat = getHeartbeat(name_);
-  auto & signal = heartbeat.getSignal("heartbeat");
-  // Increment heartbeat
-  signal.setValue<uint32_t>(signal.getValue<uint32_t>() + 1);
-  return sendBundle(heartbeat);
-}
-
 proton_status_e Node::registerCallback(
   const std::string & bundle_name, BundleHandle::BundleCallback callback)
 {
   auto & bundle = getBundle(bundle_name);
-
-  if (callback != nullptr)
-  {
-    for (const auto & consumer : bundle.getConsumers())
-    {
-      if (consumer == name_)
-      {
-        bundle.registerCallback(callback);
-        return PROTON_OK;
-      }
-    }
-  }
-
-  return PROTON_ERROR;
-}
-
-proton_status_e Node::registerHeartbeatCallback(
-  const std::string & producer, BundleHandle::BundleCallback callback)
-{
-  auto & bundle = getHeartbeat(producer);
 
   if (callback != nullptr)
   {
@@ -300,26 +245,9 @@ void Node::runStatsThread()
         handle.resetRxCount();
         handle.resetTxCount();
       }
-
-      for (auto & [name, handle] : heartbeat_bundles_)
-      {
-        handle.setRxps(handle.getRxCount());
-        handle.setTxps(handle.getTxCount());
-        handle.resetRxCount();
-        handle.resetTxCount();
-      }
     }
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
-  }
-}
-
-void Node::runHeartbeatThread()
-{
-  while (1)
-  {
-    sendHeartbeat();
-    std::this_thread::sleep_for(std::chrono::milliseconds(node_config_.heartbeat.period));
   }
 }
 
@@ -334,7 +262,6 @@ void Node::printStats()
   for (auto & [name, peer] : connections_)
   {
     std::cout << "  " << name << ":" << std::endl;
-    std::cout << "    Heartbeat: " << peer.getNodeState() << std::endl;
     std::cout << "    Transport (" << peer.getTransportType() << "): " << peer.getTransportState()
               << std::endl;
     std::cout << "    Rx: " << peer.getRxKbps() << " KB/s " << "Tx: " << peer.getTxKbps() << " KB/s"
@@ -354,17 +281,6 @@ void Node::printStats()
   }
   std::cout << "----- Consumed Bundles (hz) -----" << std::endl;
   for (auto & [name, handle] : bundles_)
-  {
-    for (auto & consumer : handle.getConsumers())
-    {
-      if (consumer == name_)
-      {
-        std::cout << name << ": " << handle.getRxps() << std::endl;
-      }
-    }
-  }
-  std::cout << "----- Heartbeats (hz) -----" << std::endl;
-  for (auto & [name, handle] : heartbeat_bundles_)
   {
     for (auto & consumer : handle.getConsumers())
     {
@@ -436,41 +352,7 @@ Connection::Connection(
   state_ = PROTON_NODE_INACTIVE;
 }
 
-void Connection::run()
-{
-  run_thread_ = std::thread(&Connection::spin, this);
-
-  if (config_.heartbeat.enabled)
-  {
-    heartbeat_thread_ = std::thread(&Connection::checkHeartbeat, this);
-  }
-}
-
-void Connection::checkHeartbeat()
-{
-  while (1)
-  {
-    std::this_thread::sleep_for(std::chrono::milliseconds(config_.heartbeat.period));
-
-    if (
-      std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::system_clock::now().time_since_epoch())
-          .count() -
-        last_heartbeat_ms_ >
-      config_.heartbeat.period)
-    {
-      state_ = PROTON_NODE_INACTIVE;
-    }
-  }
-}
-
-void Connection::heartbeat()
-{
-  state_ = PROTON_NODE_ACTIVE;
-  last_heartbeat_ms_ = std::chrono::duration_cast<std::chrono::milliseconds>(
-                         std::chrono::system_clock::now().time_since_epoch())
-                         .count();
-}
+void Connection::run() { run_thread_ = std::thread(&Connection::spin, this); }
 
 void Connection::spin()
 {
@@ -549,11 +431,6 @@ proton_status_e Connection::pollForBundle()
     if (!bundle.ParseFromArray(read_buf, bytes_read))
     {
       return PROTON_SERIALIZATION_ERROR;
-    }
-
-    if (bundle.id() == 0)
-    {
-      heartbeat();
     }
 
     return callback_(bundle, config_.name);

--- a/tests/protonc/proton_test.cpp
+++ b/tests/protonc/proton_test.cpp
@@ -59,8 +59,6 @@ TEST(PROTONC_Proton, InitNode)
     PROTON_OK);
 
   ASSERT_STREQ(producer_node.name, PROTON__NODE__PRODUCER__NAME);
-  ASSERT_EQ(producer_node.heartbeat.enabled, PROTON__NODE__PRODUCER__HEARTBEAT__ENABLED);
-  ASSERT_EQ(producer_node.heartbeat.period, PROTON__NODE__PRODUCER__HEARTBEAT__PERIOD);
   ASSERT_EQ(
     producer_node.peers[PROTON__PEER__CONSUMER].transport.connect,
     proton_node_consumer_transport_connect);


### PR DESCRIPTION
Part of the larger proton re-architecture [here](https://otto-ra.atlassian.net/wiki/spaces/PFT/pages/344948755/Proton+Reorganization+and+Core+Library) (internal CPR/OTTO employee eyes only 👀 )

Proton implicitly creates `heartbeat` bundles for nodes (if specified in the yaml). These heartbeats are simply bundles that are sent at a periodic rate. There is no special logic to handling timeouts, it's all user-supplied external to proton. Proton also doesn't handle the transmission rate of the heartbeats. This means that they're essentially a hidden bundle with extra autogen logic, but they operate no differently from a regular bundle.

This PR removes the special heartbeat logic from autogeneration, protonc, and protoncpp. The examples are updated to use heartbeats as bundles that are no different from the other ones, and continue the logic of marking a transport as disconnected after a timeout.

This PR also harmonizes how the CPP examples print heartbeat bundles, which was all over the place previously. We _really_ need to consolidate these examples.

Of particular note is that this _doesn't_ break existing deployments, because the callback names and ID's are the same. The only thing I can think of that may break is that the bundle ID for heartbeats is no longer 0, so it should be like a one line change for each heartbeat across our firmware. ezpz.