### PR TITLE
Add callback table with user args

### DIFF
--- a/core/generator_scripts/resources/target_registry.c.jinja
+++ b/core/generator_scripts/resources/target_registry.c.jinja
@@ -137,13 +137,9 @@ proton_Signal* g_bundle_signal_ptrs[PROTON_BUNDLE_REGISTRY_SIZE] = {
 {% endfor %}
 };
 
-void proton_dummy_bundle_callback(uint32_t bundle_id, const uint32_t * signal_ids, size_t num_ids, void * context)
-{
-}
-
 proton_bundle_cb_t g_bundle_callbacks[PROTON_BUNDLE_REGISTRY_SIZE] = {
 {% for bundle in bundles %}
-  { proton_dummy_bundle_callback, NULL },
+  { NULL, NULL },
 {% endfor %}
 };
 

--- a/core/generator_scripts/resources/target_registry.c.jinja
+++ b/core/generator_scripts/resources/target_registry.c.jinja
@@ -137,6 +137,16 @@ proton_Signal* g_bundle_signal_ptrs[PROTON_BUNDLE_REGISTRY_SIZE] = {
 {% endfor %}
 };
 
+void proton_dummy_bundle_callback(uint32_t bundle_id, const uint32_t * signal_ids, size_t num_ids, void * context)
+{
+}
+
+proton_bundle_cb_t g_bundle_callbacks[PROTON_BUNDLE_REGISTRY_SIZE] = {
+{% for bundle in bundles %}
+  { proton_dummy_bundle_callback, NULL },
+{% endfor %}
+};
+
 // Scratch buffer used as a temporary decode target for string/bytes signals
 // TODO manage the size of this buffer at build time
 static uint8_t g_signal_decode_scratch[1024];
@@ -144,6 +154,8 @@ static uint8_t g_signal_decode_scratch[1024];
 proton_registry_t g_proton_registry = {
   .bundle_table = g_bundle_table,
   .bundle_id_lut = g_bundle_id_lut,
+  .bundle_callbacks = g_bundle_callbacks,
+
   .bundle_count = PROTON_BUNDLE_REGISTRY_SIZE,
   .bundle_signal_ptrs = g_bundle_signal_ptrs,
   .signal_registry = g_signal_registry,

--- a/core/include/proton/registry.h
+++ b/core/include/proton/registry.h
@@ -124,7 +124,6 @@ extern "C"
     const bundle_desc_t * bundle_table;
     const id_to_index_t * bundle_id_lut;
     proton_bundle_cb_t * bundle_callbacks;
-    void ** bundle_callback_args;
     size_t bundle_count;
 
     // Buffers for encoding/decoding signals per bundle.

--- a/core/include/proton/registry.h
+++ b/core/include/proton/registry.h
@@ -34,6 +34,18 @@ extern "C"
 {
 #endif
 
+  /**
+   * @typedef proton bundle callback, called when a bundle is successfully decoded
+   * parameters are: bundle ID, array of signal ID's associated with bundle, void* for user context
+   */
+  typedef void (*proton_bundle_cb_f)(uint32_t, const uint32_t *, size_t, void *);
+
+  typedef struct proton_bundle_cb
+  {
+    proton_bundle_cb_f cb;
+    void * arg;
+  } proton_bundle_cb_t;
+
   typedef enum
   {
     PROTON_INVALID_TYPE = 0,
@@ -111,6 +123,8 @@ extern "C"
     // Since the bundle IDs are not contiguous, the bundle_id_lut is used to find the index of a bundle descriptor
     const bundle_desc_t * bundle_table;
     const id_to_index_t * bundle_id_lut;
+    proton_bundle_cb_t * bundle_callbacks;
+    void ** bundle_callback_args;
     size_t bundle_count;
 
     // Buffers for encoding/decoding signals per bundle.
@@ -147,6 +161,18 @@ extern "C"
    */
   proton_Signal * proton_registry_get_bundle_encode_decode_buffer(
     const proton_registry_t * registry, uint32_t bundle_id);
+
+  /**
+   * Get the callback for a bundle
+   */
+  proton_bundle_cb_t * proton_registry_get_bundle_callback(
+    const proton_registry_t * registry, uint32_t bundle_id);
+
+  /**
+   * Set the callback for a successful bundle decode
+   */
+  void proton_registry_set_bundle_callback(
+    proton_registry_t * registry, uint32_t bundle_id, proton_bundle_cb_f bundle_cb, void * context);
 
   /**
    * Get the signal from a registry by ID

--- a/core/src/encode_decode.c
+++ b/core/src/encode_decode.c
@@ -369,9 +369,13 @@ proton_status_e proton_decode(proton_registry_t * registry, uint8_t * buffer, si
   {
     proton_bundle_cb_t * callback =
       proton_registry_get_bundle_callback(registry, bundle_desc->bundle_id);
-    callback->cb(
-      bundle_desc->bundle_id, bundle_desc->signal_ids.ids, bundle_desc->signal_ids.count,
-      callback->arg);
+
+    if (callback != NULL && callback->cb != NULL)
+    {
+      callback->cb(
+        bundle_desc->bundle_id, bundle_desc->signal_ids.ids, bundle_desc->signal_ids.count,
+        callback->arg);
+    }
     return PROTON_OK;
   }
   else

--- a/core/src/encode_decode.c
+++ b/core/src/encode_decode.c
@@ -367,6 +367,11 @@ proton_status_e proton_decode(proton_registry_t * registry, uint8_t * buffer, si
 
   if (stream.bytes_left == 0)
   {
+    proton_bundle_cb_t * callback =
+      proton_registry_get_bundle_callback(registry, bundle_desc->bundle_id);
+    callback->cb(
+      bundle_desc->bundle_id, bundle_desc->signal_ids.ids, bundle_desc->signal_ids.count,
+      callback->arg);
     return PROTON_OK;
   }
   else

--- a/core/src/registry.c
+++ b/core/src/registry.c
@@ -89,6 +89,8 @@ proton_bundle_cb_t * proton_registry_get_bundle_callback(
       return &registry->bundle_callbacks[registry->bundle_id_lut[i].idx];
     }
   }
+
+  return NULL;
 }
 
 void proton_registry_set_bundle_callback(

--- a/core/src/registry.c
+++ b/core/src/registry.c
@@ -79,6 +79,31 @@ proton_Signal * proton_registry_get_bundle_encode_decode_buffer(
   return NULL;
 }
 
+proton_bundle_cb_t * proton_registry_get_bundle_callback(
+  const proton_registry_t * registry, uint32_t bundle_id)
+{
+  for (size_t i = 0; i < registry->bundle_count; i++)
+  {
+    if (registry->bundle_id_lut[i].id == bundle_id)
+    {
+      return &registry->bundle_callbacks[registry->bundle_id_lut[i].idx];
+    }
+  }
+}
+
+void proton_registry_set_bundle_callback(
+  proton_registry_t * registry, uint32_t bundle_id, proton_bundle_cb_f bundle_cb, void * context)
+{
+  for (size_t i = 0; i < registry->bundle_count; i++)
+  {
+    if (registry->bundle_id_lut[i].id == bundle_id)
+    {
+      registry->bundle_callbacks[registry->bundle_id_lut[i].idx].cb = bundle_cb;
+      registry->bundle_callbacks[registry->bundle_id_lut[i].idx].arg = context;
+    }
+  }
+}
+
 signal_desc_t * proton_registry_get_signal(
   const proton_registry_t * registry, uint32_t signal_id, size_t * registry_idx)
 {

--- a/core/tests/core/encode_decode_test.cpp
+++ b/core/tests/core/encode_decode_test.cpp
@@ -239,10 +239,38 @@ TEST(EncodeDecode, SignalSharedBetweenBundles)
 
 TEST(EncodeDecode, BundleDecodeCallback)
 {
-  bool cb_called = false;
+  class CheckSignalsInBundleCallback : BundleCallback
+  {
+  public:
+    CheckSignalsInBundleCallback(uint32_t id, proton_registry * registry) : id_(id), reg_(registry)
+    {
+      proton_registry_set_bundle_callback(
+        registry, PROTON_BUNDLE_DEFAULT_VALUE_TEST_ID, bundle_cb, this);
+    }
+
+    void callback(uint32_t bundle_id, const uint32_t * signal_ids, size_t num_ids) override
+    {
+      EXPECT_EQ(bundle_id, id_);
+      cb_called_ = true;
+
+      const bundle_desc_t * desc = proton_registry_get_bundle(reg_, id_, NULL);
+
+      for (size_t i = 0; i < num_ids; i++)
+      {
+        EXPECT_EQ(signal_ids[i], desc->signal_ids.ids[i]);
+      }
+    }
+
+    bool cb_called_{false};
+
+  private:
+    uint32_t id_;
+    proton_registry * reg_;
+  };
+
   proton_registry_t registry = copy_default_registry(&g_proton_registry);
-  proton_registry_set_bundle_callback(
-    &registry, PROTON_BUNDLE_DEFAULT_VALUE_TEST_ID, test_bundle_callback, (void *)&cb_called);
+
+  auto check_cb = CheckSignalsInBundleCallback(PROTON_BUNDLE_DEFAULT_VALUE_TEST_ID, &registry);
 
   uint8_t raw[BUFFER_SIZE];
   size_t bytes_encoded = 0;
@@ -255,7 +283,7 @@ TEST(EncodeDecode, BundleDecodeCallback)
 
   ASSERT_EQ(proton_decode(&registry, raw, bytes_encoded), PROTON_OK);
 
-  EXPECT_TRUE(cb_called);
+  EXPECT_TRUE(check_cb.cb_called_);
 }
 
 int main(int argc, char ** argv)

--- a/core/tests/core/encode_decode_test.cpp
+++ b/core/tests/core/encode_decode_test.cpp
@@ -28,6 +28,38 @@ static constexpr size_t BUFFER_SIZE = 1024;
 
 extern proton_registry_t g_proton_registry;
 
+/**
+ * @class CheckSignalsInBundleCallback utility class for testing bundle callbacks
+ */
+class CheckSignalsInBundleCallback : BundleCallback
+{
+public:
+  CheckSignalsInBundleCallback(uint32_t id, proton_registry * registry) : id_(id), reg_(registry)
+  {
+    proton_registry_set_bundle_callback(
+      registry, PROTON_BUNDLE_DEFAULT_VALUE_TEST_ID, bundle_cb, this);
+  }
+
+  void callback(uint32_t bundle_id, const uint32_t * signal_ids, size_t num_ids) override
+  {
+    EXPECT_EQ(bundle_id, id_);
+    cb_called_ = true;
+
+    const bundle_desc_t * desc = proton_registry_get_bundle(reg_, id_, NULL);
+
+    for (size_t i = 0; i < num_ids; i++)
+    {
+      EXPECT_EQ(signal_ids[i], desc->signal_ids.ids[i]);
+    }
+  }
+
+  bool cb_called_{false};
+
+private:
+  uint32_t id_;
+  proton_registry * reg_;
+};
+
 // -----------------------------------------------------------------------
 // Encode
 // -----------------------------------------------------------------------
@@ -239,35 +271,6 @@ TEST(EncodeDecode, SignalSharedBetweenBundles)
 
 TEST(EncodeDecode, BundleDecodeCallback)
 {
-  class CheckSignalsInBundleCallback : BundleCallback
-  {
-  public:
-    CheckSignalsInBundleCallback(uint32_t id, proton_registry * registry) : id_(id), reg_(registry)
-    {
-      proton_registry_set_bundle_callback(
-        registry, PROTON_BUNDLE_DEFAULT_VALUE_TEST_ID, bundle_cb, this);
-    }
-
-    void callback(uint32_t bundle_id, const uint32_t * signal_ids, size_t num_ids) override
-    {
-      EXPECT_EQ(bundle_id, id_);
-      cb_called_ = true;
-
-      const bundle_desc_t * desc = proton_registry_get_bundle(reg_, id_, NULL);
-
-      for (size_t i = 0; i < num_ids; i++)
-      {
-        EXPECT_EQ(signal_ids[i], desc->signal_ids.ids[i]);
-      }
-    }
-
-    bool cb_called_{false};
-
-  private:
-    uint32_t id_;
-    proton_registry * reg_;
-  };
-
   proton_registry_t registry = copy_default_registry(&g_proton_registry);
 
   auto check_cb = CheckSignalsInBundleCallback(PROTON_BUNDLE_DEFAULT_VALUE_TEST_ID, &registry);
@@ -284,6 +287,25 @@ TEST(EncodeDecode, BundleDecodeCallback)
   ASSERT_EQ(proton_decode(&registry, raw, bytes_encoded), PROTON_OK);
 
   EXPECT_TRUE(check_cb.cb_called_);
+}
+
+TEST(EncodeDecode, NoCallbackForBadDecode)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+
+  auto check_cb = CheckSignalsInBundleCallback(PROTON_BUNDLE_DEFAULT_VALUE_TEST_ID, &registry);
+
+  uint8_t raw[BUFFER_SIZE];
+  size_t bytes_encoded = 0;
+
+  ASSERT_EQ(
+    proton_encode_bundle(
+      &registry, PROTON_BUNDLE_DEFAULT_VALUE_TEST_ID, raw, sizeof(raw), &bytes_encoded),
+    PROTON_OK);
+  ASSERT_GT(bytes_encoded, 0);
+
+  EXPECT_EQ(proton_decode(&registry, raw, bytes_encoded / 2), PROTON_SERIALIZATION_ERROR);
+  EXPECT_FALSE(check_cb.cb_called_);
 }
 
 int main(int argc, char ** argv)

--- a/core/tests/core/encode_decode_test.cpp
+++ b/core/tests/core/encode_decode_test.cpp
@@ -31,13 +31,12 @@ extern proton_registry_t g_proton_registry;
 /**
  * @class CheckSignalsInBundleCallback utility class for testing bundle callbacks
  */
-class CheckSignalsInBundleCallback : BundleCallback
+class CheckSignalsInBundleCallback : public BundleCallback
 {
 public:
   CheckSignalsInBundleCallback(uint32_t id, proton_registry * registry) : id_(id), reg_(registry)
   {
-    proton_registry_set_bundle_callback(
-      registry, PROTON_BUNDLE_DEFAULT_VALUE_TEST_ID, bundle_cb, this);
+    proton_registry_set_bundle_callback(registry, id, bundle_cb, this);
   }
 
   void callback(uint32_t bundle_id, const uint32_t * signal_ids, size_t num_ids) override

--- a/core/tests/core/encode_decode_test.cpp
+++ b/core/tests/core/encode_decode_test.cpp
@@ -287,6 +287,7 @@ TEST(EncodeDecode, BundleDecodeCallback)
   ASSERT_EQ(proton_decode(&registry, raw, bytes_encoded), PROTON_OK);
 
   EXPECT_TRUE(check_cb.cb_called_);
+  free(registry.signal_registry);
 }
 
 TEST(EncodeDecode, NoCallbackForBadDecode)
@@ -306,6 +307,7 @@ TEST(EncodeDecode, NoCallbackForBadDecode)
 
   EXPECT_EQ(proton_decode(&registry, raw, bytes_encoded / 2), PROTON_SERIALIZATION_ERROR);
   EXPECT_FALSE(check_cb.cb_called_);
+  free(registry.signal_registry);
 }
 
 int main(int argc, char ** argv)

--- a/core/tests/core/encode_decode_test.cpp
+++ b/core/tests/core/encode_decode_test.cpp
@@ -237,6 +237,27 @@ TEST(EncodeDecode, SignalSharedBetweenBundles)
   free(registry.signal_registry);
 }
 
+TEST(EncodeDecode, BundleDecodeCallback)
+{
+  bool cb_called = false;
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  proton_registry_set_bundle_callback(
+    &registry, PROTON_BUNDLE_DEFAULT_VALUE_TEST_ID, test_bundle_callback, (void *)&cb_called);
+
+  uint8_t raw[BUFFER_SIZE];
+  size_t bytes_encoded = 0;
+
+  ASSERT_EQ(
+    proton_encode_bundle(
+      &registry, PROTON_BUNDLE_DEFAULT_VALUE_TEST_ID, raw, sizeof(raw), &bytes_encoded),
+    PROTON_OK);
+  ASSERT_GT(bytes_encoded, 0);
+
+  ASSERT_EQ(proton_decode(&registry, raw, bytes_encoded), PROTON_OK);
+
+  EXPECT_TRUE(cb_called);
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/core/tests/core/utils.hpp
+++ b/core/tests/core/utils.hpp
@@ -23,17 +23,33 @@
 #include <cstring>
 #include "proton/registry.h"
 
-proton_registry_t copy_default_registry(proton_registry_t * original_registry)
+#ifdef __cplusplus
+extern "C"
 {
-  proton_registry_t copy = *original_registry;
-  // Deep copy the signal registry since we will be modifying signal values in some tests
-  signal_desc_t * signal_registry_copy =
-    (signal_desc_t *)malloc(sizeof(signal_desc_t) * copy.signal_count);
-  memcpy(
-    signal_registry_copy, original_registry->signal_registry,
-    sizeof(signal_desc_t) * copy.signal_count);
-  copy.signal_registry = signal_registry_copy;
-  return copy;
+#endif
+
+  proton_registry_t copy_default_registry(proton_registry_t * original_registry)
+  {
+    proton_registry_t copy = *original_registry;
+    // Deep copy the signal registry since we will be modifying signal values in some tests
+    signal_desc_t * signal_registry_copy =
+      (signal_desc_t *)malloc(sizeof(signal_desc_t) * copy.signal_count);
+    memcpy(
+      signal_registry_copy, original_registry->signal_registry,
+      sizeof(signal_desc_t) * copy.signal_count);
+    copy.signal_registry = signal_registry_copy;
+    return copy;
+  }
+
+  void test_bundle_callback(
+    uint32_t bundle_id, const uint32_t * signal_ids, size_t num_ids, void * context)
+  {
+    bool * user_arg = (bool *)context;
+    *user_arg = true;
+  }
+
+#ifdef __cplusplus
 }
+#endif
 
 #endif  // PROTON_CORE_TESTS_CORE_UTILS_HPP

--- a/core/tests/core/utils.hpp
+++ b/core/tests/core/utils.hpp
@@ -41,7 +41,7 @@ extern "C"
 
     // Deep copy bundle callbacks
     proton_bundle_cb_t * bundle_cb_copy =
-      (proton_bundle_cb_t *)malloc(sizeof(proton_bundle_cb_t *) * copy.bundle_count);
+      (proton_bundle_cb_t *)malloc(sizeof(proton_bundle_cb_t) * copy.bundle_count);
     memcpy(
       bundle_cb_copy, original_registry->bundle_callbacks,
       sizeof(proton_bundle_cb_t) * copy.bundle_count);

--- a/core/tests/core/utils.hpp
+++ b/core/tests/core/utils.hpp
@@ -38,6 +38,15 @@ extern "C"
       signal_registry_copy, original_registry->signal_registry,
       sizeof(signal_desc_t) * copy.signal_count);
     copy.signal_registry = signal_registry_copy;
+
+    // Deep copy bundle callbacks
+    proton_bundle_cb_t * bundle_cb_copy =
+      (proton_bundle_cb_t *)malloc(sizeof(proton_bundle_cb_t *) * copy.bundle_count);
+    memcpy(
+      bundle_cb_copy, original_registry->bundle_callbacks,
+      sizeof(proton_bundle_cb_t) * copy.bundle_count);
+    copy.bundle_callbacks = bundle_cb_copy;
+
     return copy;
   }
 #ifdef __cplusplus

--- a/core/tests/core/utils.hpp
+++ b/core/tests/core/utils.hpp
@@ -40,16 +40,24 @@ extern "C"
     copy.signal_registry = signal_registry_copy;
     return copy;
   }
-
-  void test_bundle_callback(
-    uint32_t bundle_id, const uint32_t * signal_ids, size_t num_ids, void * context)
-  {
-    bool * user_arg = (bool *)context;
-    *user_arg = true;
-  }
-
 #ifdef __cplusplus
 }
 #endif
+
+class BundleCallback
+{
+public:
+  BundleCallback() = default;
+  virtual ~BundleCallback() = default;
+
+  virtual void callback(uint32_t bundle_id, const uint32_t * signal_ids, size_t num_ids) = 0;
+
+protected:
+  static void bundle_cb(
+    uint32_t bundle_id, const uint32_t * signal_ids, size_t num_ids, void * context)
+  {
+    reinterpret_cast<BundleCallback *>(context)->callback(bundle_id, signal_ids, num_ids);
+  }
+};
 
 #endif  // PROTON_CORE_TESTS_CORE_UTILS_HPP


### PR DESCRIPTION
Part of the larger proton re-architecture [here](https://otto-ra.atlassian.net/wiki/spaces/PFT/pages/344948755/Proton+Reorganization+and+Core+Library) (internal CPR/OTTO employee eyes only 👀 )

This feature branch re-adds the per-bundle decode callbacks from the original `protonc` library. However, instead of using weak linking. The motive for moving to "strong" linking here is largely to reduce complexity in autogen, and to provide users with the ability to not use a name-dependent function, and to even have a central signal decoding callback.