### PR TITLE
Feature: CORE-37225 periodic bundles

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -364,6 +364,38 @@ target_include_directories(multi_node_test PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/tests/core
 )
 
+set(PERIODIC_BUNDLE_TEST ${CMAKE_CURRENT_BINARY_DIR}/tests/periodic_bundle_generated)
+
+set(PERIODIC_BUNDLE_GENERATED_REGISTRY_FILES
+  "${PERIODIC_BUNDLE_TEST}/target_registry.c"
+  "${PERIODIC_BUNDLE_TEST}/target_node.c"
+  "${PERIODIC_BUNDLE_TEST}/target_registry_ids.h"
+  "${PERIODIC_BUNDLE_TEST}/target_registry_sizes.h"
+  "${PERIODIC_BUNDLE_TEST}/target_connections.h"
+)
+
+proton_core_generator(
+  "${PERIODIC_BUNDLE_GENERATED_REGISTRY_FILES}"
+  ${PERIODIC_BUNDLE_TEST}
+  "producer"
+  CONFIG_FILE ${CMAKE_CURRENT_SOURCE_DIR}/tests/core/periodic_bundle_test.yaml
+)
+
+add_executable(periodic_bundle_test
+  tests/core/periodic_bundle_test.cpp
+  ${PERIODIC_BUNDLE_GENERATED_REGISTRY_FILES}
+)
+
+target_link_libraries(periodic_bundle_test PUBLIC
+  GTest::gtest_main
+  proton::proton_core
+)
+
+target_include_directories(periodic_bundle_test PUBLIC
+  ${PERIODIC_BUNDLE_TEST}
+  ${CMAKE_CURRENT_SOURCE_DIR}/tests/core
+)
+
 include(GoogleTest)
 gtest_discover_tests(registry_test)
 gtest_discover_tests(encode_decode_test)
@@ -371,3 +403,4 @@ gtest_discover_tests(serial_transport_test)
 gtest_discover_tests(udp4_transport_test)
 gtest_discover_tests(node_manager_test)
 gtest_discover_tests(multi_node_test)
+gtest_discover_tests(periodic_bundle_test)

--- a/core/generator_scripts/generator.py
+++ b/core/generator_scripts/generator.py
@@ -26,6 +26,7 @@ from config import validate_ids
 from jinja2 import Template
 from normalize import (
     normalize_signals,
+    set_bundle_periods,
     set_node_endpoint_address,
     set_producer_consumer_ids,
 )
@@ -141,6 +142,7 @@ def main():
     set_node_endpoint_address(config['nodes'])
     normalize_signals(config['signals'])
     set_producer_consumer_ids(config['bundles'], config['nodes'])
+    set_bundle_periods(config['bundles'])
 
     generate(
         dest_path,

--- a/core/generator_scripts/normalize.py
+++ b/core/generator_scripts/normalize.py
@@ -116,3 +116,15 @@ def set_producer_consumer_ids(bundles: list[dict], nodes: list[dict]):
     for bundle in bundles:
         bundle['producer_ids'] = [node_id_map[name] for name in bundle.get('producers', [])]
         bundle['consumer_ids'] = [node_id_map[name] for name in bundle.get('consumers', [])]
+
+
+def set_bundle_periods(bundles: list[dict]):
+    """
+    Set the transmission period of each bundle, defaulting to 0.
+
+    Args:
+        bundles: "bundles" stanza in proton config
+
+    """
+    for bundle in bundles:
+        bundle.setdefault('period_ms', 0)

--- a/core/generator_scripts/resources/target_registry.c.jinja
+++ b/core/generator_scripts/resources/target_registry.c.jinja
@@ -107,6 +107,7 @@ bundle_desc_t g_bundle_table[PROTON_BUNDLE_REGISTRY_SIZE] = {
       .count = {{ bundle.signals | length }}
     },
     .last_send_ms = 0,
+    .period_ms = {{ bundle.period_ms }},
     .send_now = false,
   },
 {% endif %}

--- a/core/include/proton/node_manager.h
+++ b/core/include/proton/node_manager.h
@@ -81,12 +81,13 @@ extern "C"
    * Update function to be called periodically by the user to check if there are any messages to send
    * This function will encode bundles by a priority scheme:
    *   - "triggered" bundles (see proton_node_trigger_bundle) are prioritized over non-triggered bundles
-   *   - bundles with older last-send timestamps are prioritized over newer ones.
+   *   - "most overdue" bundles are prioritized over less overdue bundles
+   *   - in the event of no overdue bundles, bundles with older last-send timestamps are prioritized over newer ones.
    * The priority order is essentially as follows:
+   *   - "most overdue" triggered bundles
    *   - triggered bundles with oldest last send time
    *   - triggered bundles with newer last send time
-   *   - non-triggered bundles with oldest last send time
-   *   - non-triggered bundles with newer last send time
+   *   - "most overdue" non-triggered bundles
    */
   proton_status_e proton_node_update(
     proton_core_node_t * node, uint64_t uptime_ms, uint8_t * buffer, size_t buffer_len,

--- a/core/include/proton/node_manager.h
+++ b/core/include/proton/node_manager.h
@@ -85,8 +85,6 @@ extern "C"
    *   - in the event of no overdue bundles, bundles with older last-send timestamps are prioritized over newer ones.
    * The priority order is essentially as follows:
    *   - "most overdue" triggered bundles
-   *   - triggered bundles with oldest last send time
-   *   - triggered bundles with newer last send time
    *   - "most overdue" non-triggered bundles
    */
   proton_status_e proton_node_update(

--- a/core/include/proton/registry.h
+++ b/core/include/proton/registry.h
@@ -177,6 +177,12 @@ extern "C"
     proton_registry_t * registry, uint32_t bundle_id, proton_bundle_cb_f bundle_cb, void * context);
 
   /**
+   * Set bundle period for a bundle in the registry
+   */
+  void proton_registry_set_bundle_period(
+    proton_registry_t * registry, uint32_t bundle_id, uint32_t period_ms);
+
+  /**
    * Get the signal from a registry by ID
    * registry_idx is optional output parameter for the index of the signal in the registry
    * @return pointer to the signal descriptor, or NULL if not found

--- a/core/include/proton/registry.h
+++ b/core/include/proton/registry.h
@@ -98,6 +98,7 @@ extern "C"
     proton_id_list_t consumer_ids;
     proton_id_list_t signal_ids;
     uint64_t last_send_ms;
+    // NOTE: 0 means no period, and will only be sent if triggered or directly requested in the node manager API
     uint32_t period_ms;
     bool send_now;
   } bundle_desc_t;

--- a/core/include/proton/registry.h
+++ b/core/include/proton/registry.h
@@ -98,6 +98,7 @@ extern "C"
     proton_id_list_t consumer_ids;
     proton_id_list_t signal_ids;
     uint64_t last_send_ms;
+    uint32_t period_ms;
     bool send_now;
   } bundle_desc_t;
 

--- a/core/src/node_manager.c
+++ b/core/src/node_manager.c
@@ -128,10 +128,15 @@ proton_status_e proton_node_update(
     return PROTON_NULL_PTR_ERROR;
   }
 
+  if (num_dest_peers == 0)
+  {
+    return PROTON_INSUFFICIENT_BUFFER_ERROR;
+  }
+
   bool something_to_send = false;
 
   uint32_t bundle_to_send = 0;
-  uint64_t oldest_timestamp = UINT64_MAX;
+  uint64_t most_overdue_ms = 0;
   bool send_now_flag = false;
   size_t slot_id = 0;
 
@@ -144,37 +149,42 @@ proton_status_e proton_node_update(
 
   for (size_t i = 0; i < node->registry->bundle_count; i++)
   {
-    // Prioritize in the following manner:
-    // 1. Bundles marked to be sent now, prioritize the oldest send time
-    // 2. If no send-now flags, send the oldest bundle
     bundle_desc_t * bundle_desc = &node->registry->bundle_table[i];
-    // If this is our first send-now flag, the priority timestamp becomes the send-now timestamp
+    // Check triggered bundles
     if (bundle_desc->send_now)
     {
+      // If this is our first triggered bundle, we will skip looking at non-triggered bundles (via send_now_flag)
       if (!send_now_flag)
       {
         send_now_flag = true;
         bundle_to_send = bundle_desc->bundle_id;
-        oldest_timestamp = bundle_desc->last_send_ms;
+        most_overdue_ms = (uptime_ms - bundle_desc->last_send_ms) - bundle_desc->period_ms;
         slot_id = i;
         something_to_send = true;
       }
-      else if (bundle_desc->last_send_ms <= oldest_timestamp)
+      // Check if this triggered bundle is more overdue than our current candidate triggered bundle
+      else if ((uptime_ms - bundle_desc->last_send_ms) - bundle_desc->period_ms >= most_overdue_ms)
       {
         bundle_to_send = bundle_desc->bundle_id;
-        oldest_timestamp = bundle_desc->last_send_ms;
+        most_overdue_ms = (uptime_ms - bundle_desc->last_send_ms) - bundle_desc->period_ms;
         slot_id = i;
         something_to_send = true;
       }
     }
+    // No triggered bundles, check non-triggered bundles for the most overdue bundle to send
     else if (!send_now_flag)
     {
-      if (bundle_desc->last_send_ms <= oldest_timestamp)
+      if (
+        bundle_desc->period_ms != 0 &&
+        uptime_ms - bundle_desc->last_send_ms >= bundle_desc->period_ms)
       {
-        bundle_to_send = bundle_desc->bundle_id;
-        oldest_timestamp = bundle_desc->last_send_ms;
-        slot_id = i;
-        something_to_send = true;
+        if ((uptime_ms - bundle_desc->last_send_ms) - bundle_desc->period_ms >= most_overdue_ms)
+        {
+          bundle_to_send = bundle_desc->bundle_id;
+          most_overdue_ms = (uptime_ms - bundle_desc->last_send_ms) - bundle_desc->period_ms;
+          slot_id = i;
+          something_to_send = true;
+        }
       }
     }
   }
@@ -228,6 +238,11 @@ proton_status_e proton_node_encode_bundle(
     dest_peers == NULL || num_selected_peers == NULL)
   {
     return PROTON_NULL_PTR_ERROR;
+  }
+
+  if (num_dest_peers == 0)
+  {
+    return PROTON_INSUFFICIENT_BUFFER_ERROR;
   }
 
   size_t slot_id;

--- a/core/src/node_manager.c
+++ b/core/src/node_manager.c
@@ -187,7 +187,7 @@ proton_status_e proton_node_update(
         something_to_send = true;
       }
       // Check if this triggered bundle is more overdue than our current candidate triggered bundle
-      else if (candidate_overdue > most_overdue_ms)
+      else if (candidate_overdue >= most_overdue_ms)
       {
         bundle_to_send = bundle_desc->bundle_id;
         most_overdue_ms = candidate_overdue;
@@ -205,7 +205,7 @@ proton_status_e proton_node_update(
           proton_bundle_overdue_ms(
             uptime_ms, bundle_desc->last_send_ms, bundle_desc->period_ms, &candidate_overdue))
         {
-          if (candidate_overdue > most_overdue_ms)
+          if (candidate_overdue >= most_overdue_ms)
           {
             bundle_to_send = bundle_desc->bundle_id;
             most_overdue_ms = candidate_overdue;

--- a/core/src/node_manager.c
+++ b/core/src/node_manager.c
@@ -26,11 +26,17 @@
  * Unsigned subtraction (uptime_ms - last_send_ms) is intentional: it handles uptime_ms
  * counter wraparound correctly on any architecture where uint64_t arithmetic wraps modulo 2^64.
  */
-static uint64_t proton_bundle_overdue_ms(
-  uint64_t uptime_ms, uint64_t last_send_ms, uint32_t period_ms)
+static bool proton_bundle_overdue_ms(
+  uint64_t uptime_ms, uint64_t last_send_ms, uint32_t period_ms, uint64_t * overdue_ms)
 {
   uint64_t elapsed = uptime_ms - last_send_ms;
-  return (elapsed >= (uint64_t)period_ms) ? (elapsed - (uint64_t)period_ms) : 0u;
+  bool overdue = elapsed >= (uint64_t)period_ms;
+  if (overdue && overdue_ms)
+  {
+    *overdue_ms = elapsed - (uint64_t)period_ms;
+  }
+
+  return overdue;
 }
 
 /**
@@ -168,8 +174,10 @@ proton_status_e proton_node_update(
     if (bundle_desc->send_now)
     {
       // If this is our first triggered bundle, we will skip looking at non-triggered bundles (via send_now_flag)
-      uint64_t candidate_overdue =
-        proton_bundle_overdue_ms(uptime_ms, bundle_desc->last_send_ms, bundle_desc->period_ms);
+      uint64_t candidate_overdue;
+      // We also don't care about whether the triggered bundle is overdue, just how overdue it is.
+      proton_bundle_overdue_ms(
+        uptime_ms, bundle_desc->last_send_ms, bundle_desc->period_ms, &candidate_overdue);
       if (!send_now_flag)
       {
         send_now_flag = true;
@@ -179,7 +187,7 @@ proton_status_e proton_node_update(
         something_to_send = true;
       }
       // Check if this triggered bundle is more overdue than our current candidate triggered bundle
-      else if (candidate_overdue >= most_overdue_ms)
+      else if (candidate_overdue > most_overdue_ms)
       {
         bundle_to_send = bundle_desc->bundle_id;
         most_overdue_ms = candidate_overdue;
@@ -192,16 +200,12 @@ proton_status_e proton_node_update(
     {
       if (bundle_desc->period_ms != 0)
       {
-        // Explicitly handle wraparound
-        uint64_t elapsed = uptime_ms - bundle_desc->last_send_ms;
-        if (bundle_desc->last_send_ms > uptime_ms)
+        uint64_t candidate_overdue;
+        if (
+          proton_bundle_overdue_ms(
+            uptime_ms, bundle_desc->last_send_ms, bundle_desc->period_ms, &candidate_overdue))
         {
-          elapsed = uptime_ms + (UINT64_MAX - bundle_desc->last_send_ms + 1);
-        }
-        if (elapsed >= (uint64_t)bundle_desc->period_ms)
-        {
-          uint64_t candidate_overdue = elapsed - (uint64_t)bundle_desc->period_ms;
-          if (candidate_overdue >= most_overdue_ms)
+          if (candidate_overdue > most_overdue_ms)
           {
             bundle_to_send = bundle_desc->bundle_id;
             most_overdue_ms = candidate_overdue;

--- a/core/src/node_manager.c
+++ b/core/src/node_manager.c
@@ -174,7 +174,7 @@ proton_status_e proton_node_update(
     if (bundle_desc->send_now)
     {
       // If this is our first triggered bundle, we will skip looking at non-triggered bundles (via send_now_flag)
-      uint64_t candidate_overdue;
+      uint64_t candidate_overdue = 0;
       // We also don't care about whether the triggered bundle is overdue, just how overdue it is.
       proton_bundle_overdue_ms(
         uptime_ms, bundle_desc->last_send_ms, bundle_desc->period_ms, &candidate_overdue);
@@ -200,7 +200,7 @@ proton_status_e proton_node_update(
     {
       if (bundle_desc->period_ms != 0)
       {
-        uint64_t candidate_overdue;
+        uint64_t candidate_overdue = 0;
         if (
           proton_bundle_overdue_ms(
             uptime_ms, bundle_desc->last_send_ms, bundle_desc->period_ms, &candidate_overdue))

--- a/core/src/node_manager.c
+++ b/core/src/node_manager.c
@@ -20,6 +20,20 @@
 #include "proton/encode_decode.h"
 
 /**
+ * Returns how many milliseconds a bundle is overdue for sending.
+ * Returns 0 if the bundle is not yet due (elapsed < period), avoiding unsigned wraparound
+ * when a bundle is triggered before its period has elapsed.
+ * Unsigned subtraction (uptime_ms - last_send_ms) is intentional: it handles uptime_ms
+ * counter wraparound correctly on any architecture where uint64_t arithmetic wraps modulo 2^64.
+ */
+static uint64_t proton_bundle_overdue_ms(
+  uint64_t uptime_ms, uint64_t last_send_ms, uint32_t period_ms)
+{
+  uint64_t elapsed = uptime_ms - last_send_ms;
+  return (elapsed >= (uint64_t)period_ms) ? (elapsed - (uint64_t)period_ms) : 0u;
+}
+
+/**
  * Encode a bundle for sending from a node. Updates the bundle metadata in the registry
  * @NOTE the bundle ID should be set for this bundle in the registry before calling the function
  * Parameters:
@@ -154,19 +168,21 @@ proton_status_e proton_node_update(
     if (bundle_desc->send_now)
     {
       // If this is our first triggered bundle, we will skip looking at non-triggered bundles (via send_now_flag)
+      uint64_t candidate_overdue =
+        proton_bundle_overdue_ms(uptime_ms, bundle_desc->last_send_ms, bundle_desc->period_ms);
       if (!send_now_flag)
       {
         send_now_flag = true;
         bundle_to_send = bundle_desc->bundle_id;
-        most_overdue_ms = (uptime_ms - bundle_desc->last_send_ms) - bundle_desc->period_ms;
+        most_overdue_ms = candidate_overdue;
         slot_id = i;
         something_to_send = true;
       }
       // Check if this triggered bundle is more overdue than our current candidate triggered bundle
-      else if ((uptime_ms - bundle_desc->last_send_ms) - bundle_desc->period_ms >= most_overdue_ms)
+      else if (candidate_overdue >= most_overdue_ms)
       {
         bundle_to_send = bundle_desc->bundle_id;
-        most_overdue_ms = (uptime_ms - bundle_desc->last_send_ms) - bundle_desc->period_ms;
+        most_overdue_ms = candidate_overdue;
         slot_id = i;
         something_to_send = true;
       }
@@ -174,16 +190,24 @@ proton_status_e proton_node_update(
     // No triggered bundles, check non-triggered bundles for the most overdue bundle to send
     else if (!send_now_flag)
     {
-      if (
-        bundle_desc->period_ms != 0 &&
-        uptime_ms - bundle_desc->last_send_ms >= bundle_desc->period_ms)
+      if (bundle_desc->period_ms != 0)
       {
-        if ((uptime_ms - bundle_desc->last_send_ms) - bundle_desc->period_ms >= most_overdue_ms)
+        // Explicitly handle wraparound
+        uint64_t elapsed = uptime_ms - bundle_desc->last_send_ms;
+        if (bundle_desc->last_send_ms > uptime_ms)
         {
-          bundle_to_send = bundle_desc->bundle_id;
-          most_overdue_ms = (uptime_ms - bundle_desc->last_send_ms) - bundle_desc->period_ms;
-          slot_id = i;
-          something_to_send = true;
+          elapsed = uptime_ms + (UINT64_MAX - bundle_desc->last_send_ms + 1);
+        }
+        if (elapsed >= (uint64_t)bundle_desc->period_ms)
+        {
+          uint64_t candidate_overdue = elapsed - (uint64_t)bundle_desc->period_ms;
+          if (candidate_overdue >= most_overdue_ms)
+          {
+            bundle_to_send = bundle_desc->bundle_id;
+            most_overdue_ms = candidate_overdue;
+            slot_id = i;
+            something_to_send = true;
+          }
         }
       }
     }

--- a/core/src/registry.c
+++ b/core/src/registry.c
@@ -114,6 +114,7 @@ void proton_registry_set_bundle_period(
     if (registry->bundle_id_lut[i].id == bundle_id)
     {
       registry->bundle_table[registry->bundle_id_lut[i].idx].period_ms = period_ms;
+      return;
     }
   }
 }

--- a/core/src/registry.c
+++ b/core/src/registry.c
@@ -106,6 +106,18 @@ void proton_registry_set_bundle_callback(
   }
 }
 
+void proton_registry_set_bundle_period(
+  proton_registry_t * registry, uint32_t bundle_id, uint32_t period_ms)
+{
+  for (size_t i = 0; i < registry->bundle_count; i++)
+  {
+    if (registry->bundle_id_lut[i].id == bundle_id)
+    {
+      registry->bundle_table[registry->bundle_id_lut[i].idx].period_ms = period_ms;
+    }
+  }
+}
+
 signal_desc_t * proton_registry_get_signal(
   const proton_registry_t * registry, uint32_t signal_id, size_t * registry_idx)
 {

--- a/core/tests/core/node_manager_test.cpp
+++ b/core/tests/core/node_manager_test.cpp
@@ -278,9 +278,9 @@ TEST_F(NodeManagerTest, Update_SetsLastSendMs)
   // With all bundles at last_send_ms == 0 and no send_now flags, the selection algorithm
   // (using <=) picks the last bundle in the table. Verify exactly one bundle was updated.
   size_t updated_count = 0;
-  for (size_t i = 0; i < g_proton_registry.bundle_count; i++)
+  for (size_t i = 0; i < node_.registry->bundle_count; i++)
   {
-    if (g_proton_registry.bundle_table[i].last_send_ms == UPTIME_MS)
+    if (node_.registry->bundle_table[i].last_send_ms == UPTIME_MS)
     {
       updated_count++;
     }
@@ -307,11 +307,57 @@ TEST_F(NodeManagerTest, Update_TriggeredBundleIsPrioritized)
   EXPECT_GT(out_len, 0);
 
   // value_test (index 0) was sent
-  EXPECT_EQ(g_proton_registry.bundle_table[0].last_send_ms, UPTIME_MS);
-  EXPECT_FALSE(g_proton_registry.bundle_table[0].send_now);
+  EXPECT_EQ(node_.registry->bundle_table[0].last_send_ms, UPTIME_MS);
+  EXPECT_FALSE(node_.registry->bundle_table[0].send_now);
 
   // The last bundle (shared_2, index 3) was NOT sent
-  EXPECT_EQ(g_proton_registry.bundle_table[3].last_send_ms, 0ULL);
+  EXPECT_EQ(node_.registry->bundle_table[3].last_send_ms, 0ULL);
+}
+
+TEST_F(NodeManagerTest, PeriodicBundleTest)
+{
+  uint64_t uptime_ms = 1000;
+  uint8_t buf[BUFFER_SIZE];
+  size_t out_len = 0;
+  proton_endpoint_t dest[1];
+  size_t num_peers = 0;
+
+  ASSERT_EQ(
+    proton_node_update(&node_, uptime_ms, buf, sizeof(buf), &out_len, dest, 1, &num_peers),
+    PROTON_OK);
+  EXPECT_GT(out_len, 0);
+  EXPECT_EQ(num_peers, 1);
+
+  // periodic_bundle
+  size_t bundle_slot;
+  const bundle_desc_t * desc =
+    proton_registry_get_bundle(node_.registry, PROTON_BUNDLE_PERIODIC_BUNDLE_ID, &bundle_slot);
+  ASSERT_NE(desc, nullptr);
+  EXPECT_EQ(desc->last_send_ms, uptime_ms);
+
+  // Update bundle again, before the period of the periodic bundle is up
+  memset(buf, 0, BUFFER_SIZE);
+  num_peers = 0;
+  memset(dest, 0, sizeof(proton_endpoint_t));
+  uint64_t second_uptime = uptime_ms + 10;
+
+  ASSERT_EQ(
+    proton_node_update(&node_, second_uptime, buf, sizeof(buf), &out_len, dest, 1, &num_peers),
+    PROTON_OK);
+  EXPECT_GT(out_len, 0);
+  EXPECT_EQ(num_peers, 0);
+
+  EXPECT_EQ(node_.registry->bundle_table[bundle_slot].last_send_ms, uptime_ms);
+
+  // Update bundle a third time, after the bundle period has expired
+  uint64_t third_uptime = second_uptime + desc->period_ms;
+  ASSERT_EQ(
+    proton_node_update(&node_, third_uptime, buf, sizeof(buf), &out_len, dest, 1, &num_peers),
+    PROTON_OK);
+  EXPECT_GT(out_len, 0);
+  EXPECT_EQ(num_peers, 1);
+
+  EXPECT_EQ(node_.registry->bundle_table[bundle_slot].last_send_ms, third_uptime);
 }
 
 // -----------------------------------------------------------------------
@@ -438,7 +484,7 @@ TEST_F(NodeManagerTest, EncodeBundle_ValidBundle_PopulatesOutputsAndUpdatesTimes
   EXPECT_EQ(dest[0].node_id, static_cast<uint32_t>(PROTON_NODE_CONSUMER_ID));
   EXPECT_EQ(dest[0].endpoint_id, static_cast<uint32_t>(PROTON_NODE_CONSUMER_ENDPOINT_0_ID));
   // bundle_table is shared; verify last_send_ms was updated on the value_test slot (index 0)
-  EXPECT_EQ(g_proton_registry.bundle_table[0].last_send_ms, UPTIME_MS);
+  EXPECT_EQ(node_.registry->bundle_table[0].last_send_ms, UPTIME_MS);
 }
 
 TEST_F(NodeManagerTest, EncodeBundle_RoundTrip_WithReceive_SignalValuePreserved)
@@ -556,11 +602,11 @@ TEST_F(NodeManagerTest, Update_QueueTriggeredBundle_IsPrioritizedOverDefault)
 
   EXPECT_GT(out_len, 0);
   // value_test (slot 0) was the triggered bundle — its timestamp must be updated
-  EXPECT_EQ(g_proton_registry.bundle_table[0].last_send_ms, UPTIME_MS);
+  EXPECT_EQ(node_.registry->bundle_table[0].last_send_ms, UPTIME_MS);
   // The fallback bundle (shared_2, slot 3) must NOT have been sent
-  EXPECT_EQ(g_proton_registry.bundle_table[3].last_send_ms, 0ULL);
+  EXPECT_EQ(node_.registry->bundle_table[3].last_send_ms, 0ULL);
   // send_now must be cleared after sending
-  EXPECT_FALSE(g_proton_registry.bundle_table[0].send_now);
+  EXPECT_FALSE(node_.registry->bundle_table[0].send_now);
 }
 
 // -----------------------------------------------------------------------

--- a/core/tests/core/periodic_bundle_test.cpp
+++ b/core/tests/core/periodic_bundle_test.cpp
@@ -263,6 +263,125 @@ TEST_F(PeriodicBundleTest, SendMostOverdueTriggeredBundle)
   EXPECT_EQ(bundle_120_ms->last_send_ms, 0);
 }
 
+// -----------------------------------------------------------------------
+// Integer wraparound tests
+//
+// These tests verify that the unsigned subtraction (uptime_ms - last_send_ms)
+// in proton_bundle_overdue_ms handles uint64_t rollover correctly, and that
+// triggered bundles fired before their period elapses do not corrupt the
+// overdue prioritization through underflow.
+// -----------------------------------------------------------------------
+
+// A periodic bundle whose last_send_ms is just before UINT64_MAX should still
+// be sent once uptime_ms wraps past the due point.
+TEST_F(PeriodicBundleTest, Wraparound_PeriodicBundle_SentAfterThreshold)
+{
+  size_t slot;
+  bundle_desc_t * b = const_cast<bundle_desc_t *>(
+    proton_registry_get_bundle(node_.registry, PROTON_BUNDLE_100_MS_ID, &slot));
+  ASSERT_NE(b, nullptr);
+
+  // Place last_send_ms 50 ms before UINT64_MAX. Due point wraps to uptime_ms == 50.
+  b->last_send_ms = UINT64_MAX - 50;
+
+  // uptime_ms = 51 → elapsed = 51 - (UINT64_MAX - 50) = 102 ms via unsigned modular arithmetic.
+  // 102 >= 100 → bundle is due.
+  uint8_t buf[BUFFER_SIZE];
+  size_t out_len = 0;
+  proton_endpoint_t dest[1];
+  size_t num_peers = 0;
+  ASSERT_EQ(
+    proton_node_update(&node_, 51, buf, sizeof(buf), &out_len, dest, 1, &num_peers), PROTON_OK);
+
+  EXPECT_GT(out_len, 0);
+  EXPECT_EQ(b->last_send_ms, 51ULL);
+}
+
+// The same bundle must NOT be sent one millisecond before its due point crosses
+// the UINT64_MAX boundary.
+TEST_F(PeriodicBundleTest, Wraparound_PeriodicBundle_NotSentBeforeThreshold)
+{
+  size_t slot;
+  bundle_desc_t * b = const_cast<bundle_desc_t *>(
+    proton_registry_get_bundle(node_.registry, PROTON_BUNDLE_100_MS_ID, &slot));
+  ASSERT_NE(b, nullptr);
+
+  b->last_send_ms = UINT64_MAX - 50;
+
+  // uptime_ms = 48 → elapsed = 48 + 51 = 99 ms < 100 ms period → not yet due.
+  uint8_t buf[BUFFER_SIZE];
+  size_t out_len = 0;
+  proton_endpoint_t dest[1];
+  size_t num_peers = 0;
+  ASSERT_EQ(
+    proton_node_update(&node_, 48, buf, sizeof(buf), &out_len, dest, 1, &num_peers), PROTON_OK);
+
+  EXPECT_EQ(out_len, 0);
+  EXPECT_EQ(b->last_send_ms, UINT64_MAX - 50);  // unchanged
+}
+
+// A triggered bundle that has not yet reached its period should still be sent
+// immediately. This test has no wraparound on
+// uptime_ms, isolating the early-trigger underflow case.
+TEST_F(PeriodicBundleTest, Wraparound_TriggeredEarly_StillSent)
+{
+  size_t slot;
+  bundle_desc_t * b = const_cast<bundle_desc_t *>(
+    proton_registry_get_bundle(node_.registry, PROTON_BUNDLE_100_MS_ID, &slot));
+  ASSERT_NE(b, nullptr);
+
+  // 50 ms elapsed, period is 100 ms → triggered before due.
+  b->last_send_ms = 900;
+
+  proton_node_trigger_bundle(&node_, PROTON_BUNDLE_100_MS_ID);
+
+  uint8_t buf[BUFFER_SIZE];
+  size_t out_len = 0;
+  proton_endpoint_t dest[1];
+  size_t num_peers = 0;
+  ASSERT_EQ(
+    proton_node_update(&node_, 950, buf, sizeof(buf), &out_len, dest, 1, &num_peers), PROTON_OK);
+
+  EXPECT_GT(out_len, 0);
+  EXPECT_EQ(b->last_send_ms, 950ULL);
+}
+
+// Two triggered bundles where one was last sent just before UINT64_MAX and one
+// was last sent much earlier. The bundle with genuinely more elapsed time
+// (and therefore higher overdue value) must win the priority contest.
+TEST_F(PeriodicBundleTest, Wraparound_TwoTriggeredBundles_MostOverdueWins)
+{
+  size_t slot_100, slot_120;
+  bundle_desc_t * b100 = const_cast<bundle_desc_t *>(
+    proton_registry_get_bundle(node_.registry, PROTON_BUNDLE_100_MS_ID, &slot_100));
+  bundle_desc_t * b120 = const_cast<bundle_desc_t *>(
+    proton_registry_get_bundle(node_.registry, PROTON_BUNDLE_120_MS_ID, &slot_120));
+  ASSERT_NE(b100, nullptr);
+  ASSERT_NE(b120, nullptr);
+
+  // b100: last_send = UINT64_MAX - 200. At uptime=10: elapsed = 211 ms, overdue = 111 ms.
+  b100->last_send_ms = UINT64_MAX - 200;
+  // b120: last_send = UINT64_MAX - 50.  At uptime=10: elapsed = 61 ms < 120 ms, overdue = 0.
+  // Old code: overdue = 61 - 120 = UINT64_MAX - 58  → b120 would wrongly win.
+  // Fixed:    overdue = 0                            → b100 wins correctly.
+  b120->last_send_ms = UINT64_MAX - 50;
+
+  ASSERT_EQ(proton_node_trigger_bundle(&node_, PROTON_BUNDLE_100_MS_ID), PROTON_OK);
+  ASSERT_EQ(proton_node_trigger_bundle(&node_, PROTON_BUNDLE_120_MS_ID), PROTON_OK);
+
+  uint8_t buf[BUFFER_SIZE];
+  size_t out_len = 0;
+  proton_endpoint_t dest[1];
+  size_t num_peers = 0;
+  ASSERT_EQ(
+    proton_node_update(&node_, 10, buf, sizeof(buf), &out_len, dest, 1, &num_peers), PROTON_OK);
+
+  EXPECT_GT(out_len, 0);
+  // b100 has overdue = 111 ms; b120 has overdue = 0 → b100 must be selected.
+  EXPECT_EQ(b100->last_send_ms, 10ULL);
+  EXPECT_NE(b120->last_send_ms, 10ULL);
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/core/tests/core/periodic_bundle_test.cpp
+++ b/core/tests/core/periodic_bundle_test.cpp
@@ -377,6 +377,7 @@ TEST_F(PeriodicBundleTest, Wraparound_TwoTriggeredBundles_MostOverdueWins)
     proton_node_update(&node_, 10, buf, sizeof(buf), &out_len, dest, 1, &num_peers), PROTON_OK);
 
   EXPECT_GT(out_len, 0);
+  EXPECT_EQ(num_peers, 1);
   // b100 has overdue = 111 ms; b120 has overdue = 0 → b100 must be selected.
   EXPECT_EQ(b100->last_send_ms, 10ULL);
   EXPECT_NE(b120->last_send_ms, 10ULL);

--- a/core/tests/core/periodic_bundle_test.cpp
+++ b/core/tests/core/periodic_bundle_test.cpp
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2026 Rockwell Automation Technologies, Inc., All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Tom Wallis (thomas.wallis@rockwellautomation.com)
+ */
+
+#include "proton/encode_decode.h"
+#include "proton/node_manager.h"
+#include "target_connections.h"
+#include "target_registry_ids.h"
+#include "utils.hpp"
+
+#include <gtest/gtest.h>
+#include <cstring>
+
+static constexpr size_t BUFFER_SIZE = 1024;
+
+extern proton_registry_t g_proton_registry;
+extern proton_core_node_t g_target_node;
+
+// -----------------------------------------------------------------------
+// Test fixture
+// -----------------------------------------------------------------------
+
+class PeriodicBundleTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    // Reset shared bundle table state before each test.
+    // bundle_table is not deep-copied by copy_default_registry, so this affects
+    // both the global and any per-test registry copy.
+    for (size_t i = 0; i < g_proton_registry.bundle_count; i++)
+    {
+      g_proton_registry.bundle_table[i].last_send_ms = 0;
+      g_proton_registry.bundle_table[i].send_now = false;
+    }
+    registry_ = copy_default_registry(&g_proton_registry);
+    node_ = copy_default_node(&g_target_node);
+    node_.registry = &registry_;
+  }
+
+  void TearDown() override
+  {
+    free(registry_.signal_registry);
+    free(registry_.bundle_callbacks);
+  }
+
+  proton_registry_t registry_;
+  proton_core_node_t node_;
+};
+
+/**
+ * More advanced bundle periodicity tests
+ */
+
+TEST_F(PeriodicBundleTest, DoNotSendBeforeFirstPeriod)
+{
+  uint64_t uptime_ms = 10;
+  uint8_t buf[BUFFER_SIZE];
+  size_t out_len = 0;
+  proton_endpoint_t dest[1];
+  size_t num_peers = 0;
+
+  ASSERT_EQ(
+    proton_node_update(&node_, uptime_ms, buf, sizeof(buf), &out_len, dest, 1, &num_peers),
+    PROTON_OK);
+  EXPECT_EQ(out_len, 0);
+  EXPECT_EQ(num_peers, 0);
+
+  for (size_t i = 0; i < node_.registry->bundle_count; i++)
+  {
+    EXPECT_EQ(node_.registry->bundle_table[i].last_send_ms, 0);
+  }
+}
+
+TEST_F(PeriodicBundleTest, SendNextOverdueBundle)
+{
+  uint8_t buf[BUFFER_SIZE];
+  size_t out_len = 0;
+  proton_endpoint_t dest[1];
+  size_t num_peers = 0;
+
+  size_t bundle_100_ms_slot;
+  const bundle_desc_t * bundle_100_ms =
+    proton_registry_get_bundle(node_.registry, PROTON_BUNDLE_100_MS_ID, &bundle_100_ms_slot);
+  size_t bundle_120_ms_slot;
+  const bundle_desc_t * bundle_120_ms =
+    proton_registry_get_bundle(node_.registry, PROTON_BUNDLE_120_MS_ID, &bundle_120_ms_slot);
+
+  ASSERT_NE(bundle_100_ms, nullptr);
+  ASSERT_NE(bundle_120_ms, nullptr);
+
+  uint64_t first_uptime_ms = bundle_100_ms->period_ms + 1;
+
+  ASSERT_EQ(
+    proton_node_update(&node_, first_uptime_ms, buf, sizeof(buf), &out_len, dest, 1, &num_peers),
+    PROTON_OK);
+  EXPECT_GT(out_len, 0);
+  EXPECT_EQ(num_peers, 1);
+
+  EXPECT_EQ(bundle_100_ms->last_send_ms, first_uptime_ms);
+
+  uint64_t second_uptime = bundle_120_ms->period_ms + 1;
+
+  memset(buf, 0, BUFFER_SIZE);
+  num_peers = 0;
+
+  ASSERT_EQ(
+    proton_node_update(&node_, second_uptime, buf, sizeof(buf), &out_len, dest, 1, &num_peers),
+    PROTON_OK);
+  EXPECT_GT(out_len, 0);
+  EXPECT_EQ(num_peers, 1);
+
+  ASSERT_NE(bundle_120_ms, nullptr);
+  EXPECT_EQ(bundle_120_ms->last_send_ms, second_uptime);
+  EXPECT_EQ(bundle_100_ms->last_send_ms, first_uptime_ms);
+}
+
+TEST_F(PeriodicBundleTest, SendMostOverdueBundle)
+{
+  uint8_t buf[BUFFER_SIZE];
+  size_t out_len = 0;
+  proton_endpoint_t dest[1];
+  size_t num_peers = 0;
+
+  size_t bundle_100_ms_slot;
+  const bundle_desc_t * bundle_100_ms =
+    proton_registry_get_bundle(node_.registry, PROTON_BUNDLE_100_MS_ID, &bundle_100_ms_slot);
+  size_t bundle_120_ms_slot;
+  const bundle_desc_t * bundle_120_ms =
+    proton_registry_get_bundle(node_.registry, PROTON_BUNDLE_120_MS_ID, &bundle_120_ms_slot);
+
+  ASSERT_NE(bundle_100_ms, nullptr);
+  ASSERT_NE(bundle_120_ms, nullptr);
+
+  uint64_t uptime_ms = 1000;
+
+  ASSERT_EQ(
+    proton_node_update(&node_, uptime_ms, buf, sizeof(buf), &out_len, dest, 1, &num_peers),
+    PROTON_OK);
+  EXPECT_GT(out_len, 0);
+  EXPECT_EQ(num_peers, 1);
+
+  EXPECT_EQ(bundle_100_ms->last_send_ms, uptime_ms);
+  EXPECT_EQ(bundle_120_ms->last_send_ms, 0);
+}
+
+TEST_F(PeriodicBundleTest, SendTriggeredBeforeOverdue)
+{
+  uint8_t buf[BUFFER_SIZE];
+  size_t out_len = 0;
+  proton_endpoint_t dest[1];
+  size_t num_peers = 0;
+
+  size_t bundle_100_ms_slot;
+  const bundle_desc_t * bundle_100_ms =
+    proton_registry_get_bundle(node_.registry, PROTON_BUNDLE_100_MS_ID, &bundle_100_ms_slot);
+  size_t bundle_120_ms_slot;
+  const bundle_desc_t * bundle_120_ms =
+    proton_registry_get_bundle(node_.registry, PROTON_BUNDLE_120_MS_ID, &bundle_120_ms_slot);
+
+  ASSERT_NE(bundle_100_ms, nullptr);
+  ASSERT_NE(bundle_120_ms, nullptr);
+
+  EXPECT_EQ(proton_node_trigger_bundle(&node_, PROTON_BUNDLE_120_MS_ID), PROTON_OK);
+
+  uint64_t uptime_ms = 1000;
+
+  // Even though bundle 100 ms is most overdue, bundle 120 ms has been triggered, so it's taking priority
+  ASSERT_EQ(
+    proton_node_update(&node_, uptime_ms, buf, sizeof(buf), &out_len, dest, 1, &num_peers),
+    PROTON_OK);
+  EXPECT_GT(out_len, 0);
+  EXPECT_EQ(num_peers, 1);
+
+  EXPECT_EQ(bundle_100_ms->last_send_ms, 0);
+  EXPECT_EQ(bundle_120_ms->last_send_ms, uptime_ms);
+
+  // Update again, 100 ms is most overdue due to the fact that it was skipped
+  num_peers = 0;
+  uint64_t second_uptime = uptime_ms + 1;
+
+  ASSERT_EQ(
+    proton_node_update(&node_, second_uptime, buf, sizeof(buf), &out_len, dest, 1, &num_peers),
+    PROTON_OK);
+  EXPECT_GT(out_len, 0);
+  EXPECT_EQ(num_peers, 1);
+
+  EXPECT_EQ(bundle_100_ms->last_send_ms, second_uptime);
+  EXPECT_EQ(bundle_120_ms->last_send_ms, uptime_ms);
+
+  // Due to bundle 120 being triggered, its last send was set to the trigger point,
+  // so the 100 ms bundle will be sent again
+  num_peers = 0;
+  uint64_t third_uptime = second_uptime + 100;
+
+  ASSERT_EQ(
+    proton_node_update(&node_, third_uptime, buf, sizeof(buf), &out_len, dest, 1, &num_peers),
+    PROTON_OK);
+  EXPECT_GT(out_len, 0);
+  EXPECT_EQ(num_peers, 1);
+
+  EXPECT_EQ(bundle_100_ms->last_send_ms, third_uptime);
+  EXPECT_EQ(bundle_120_ms->last_send_ms, uptime_ms);
+
+  // And after the 120 ms period since the trigger point, the 120 ms bundle will finally be sent again
+  num_peers = 0;
+  uint64_t fourth_uptime = third_uptime + 20;
+
+  ASSERT_EQ(
+    proton_node_update(&node_, fourth_uptime, buf, sizeof(buf), &out_len, dest, 1, &num_peers),
+    PROTON_OK);
+  EXPECT_GT(out_len, 0);
+  EXPECT_EQ(num_peers, 1);
+
+  EXPECT_EQ(bundle_100_ms->last_send_ms, third_uptime);
+  EXPECT_EQ(bundle_120_ms->last_send_ms, fourth_uptime);
+}
+
+TEST_F(PeriodicBundleTest, SendMostOverdueTriggeredBundle)
+{
+  uint8_t buf[BUFFER_SIZE];
+  size_t out_len = 0;
+  proton_endpoint_t dest[1];
+  size_t num_peers = 0;
+
+  size_t bundle_100_ms_slot;
+  const bundle_desc_t * bundle_100_ms =
+    proton_registry_get_bundle(node_.registry, PROTON_BUNDLE_100_MS_ID, &bundle_100_ms_slot);
+  size_t bundle_120_ms_slot;
+  const bundle_desc_t * bundle_120_ms =
+    proton_registry_get_bundle(node_.registry, PROTON_BUNDLE_120_MS_ID, &bundle_120_ms_slot);
+
+  ASSERT_NE(bundle_100_ms, nullptr);
+  ASSERT_NE(bundle_120_ms, nullptr);
+
+  EXPECT_EQ(proton_node_trigger_bundle(&node_, PROTON_BUNDLE_100_MS_ID), PROTON_OK);
+  EXPECT_EQ(proton_node_trigger_bundle(&node_, PROTON_BUNDLE_120_MS_ID), PROTON_OK);
+
+  uint64_t uptime_ms = 1000;
+
+  // 100 ms is most overdue of the triggered bundles
+  ASSERT_EQ(
+    proton_node_update(&node_, uptime_ms, buf, sizeof(buf), &out_len, dest, 1, &num_peers),
+    PROTON_OK);
+  EXPECT_GT(out_len, 0);
+  EXPECT_EQ(num_peers, 1);
+
+  EXPECT_EQ(bundle_100_ms->last_send_ms, uptime_ms);
+  EXPECT_EQ(bundle_120_ms->last_send_ms, 0);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/core/tests/core/periodic_bundle_test.yaml
+++ b/core/tests/core/periodic_bundle_test.yaml
@@ -1,0 +1,36 @@
+nodes:
+  - name: producer
+    id: 0
+    endpoints:
+      - id: 0
+        type: udp4
+        ip: 127.0.0.1
+        port: 11416
+  - name: consumer
+    id: 1
+    endpoints:
+      - id: 0
+        type: udp4
+        ip: 127.0.0.1
+        port: 11417
+
+connections:
+  - first: {node: producer, id: 0}
+    second: {node: consumer, id: 0}
+
+signals:
+  - {name: double_value, id: 0x1000, type: double}
+
+bundles:
+  - name: 100_ms
+    id: 0x100
+    producers: [producer]
+    consumers: [consumer]
+    signals: [0x1000]
+    period_ms: 100
+  - name: 120_ms
+    id: 0x120
+    producers: [producer]
+    consumers: [consumer]
+    signals: [0x1000]
+    period_ms: 120

--- a/core/tests/core/registry_test.cpp
+++ b/core/tests/core/registry_test.cpp
@@ -287,6 +287,21 @@ TEST(SignalRegistry, CheckBundlePeriodPopulated)
   EXPECT_NE(periodic_bundle, nullptr);
 
   EXPECT_EQ(periodic_bundle->period_ms, 100);
+  free(registry.signal_registry);
+}
+
+TEST(SignalRegistry, SetBundlePeriod)
+{
+  const uint32_t new_period = 200;
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  proton_registry_set_bundle_period(&registry, PROTON_BUNDLE_PERIODIC_BUNDLE_ID, new_period);
+  const bundle_desc_t * periodic_bundle =
+    proton_registry_get_bundle(&registry, PROTON_BUNDLE_PERIODIC_BUNDLE_ID, NULL);
+  EXPECT_NE(periodic_bundle, nullptr);
+
+  EXPECT_EQ(periodic_bundle->period_ms, new_period);
+
+  free(registry.signal_registry);
 }
 
 int main(int argc, char ** argv)

--- a/core/tests/core/registry_test.cpp
+++ b/core/tests/core/registry_test.cpp
@@ -278,6 +278,17 @@ TEST(SignalRegistry, SetGetStringWithDifferentLength)
   free(registry.signal_registry);
 }
 
+TEST(SignalRegistry, CheckBundlePeriodPopulated)
+{
+  // This is a simple test to ensure that the autogeneration for a specific bundle has a period
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  const bundle_desc_t * periodic_bundle =
+    proton_registry_get_bundle(&registry, PROTON_BUNDLE_PERIODIC_BUNDLE_ID, NULL);
+  EXPECT_NE(periodic_bundle, nullptr);
+
+  EXPECT_EQ(periodic_bundle->period_ms, 100);
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/core/tests/core/test.yaml
+++ b/core/tests/core/test.yaml
@@ -59,3 +59,10 @@ bundles:
     producers: [producer]
     consumers: [consumer]
     signals: [0x1015]
+
+  - name: periodic_bundle
+    id: 0x104
+    producers: [producer]
+    consumers: [consumer]
+    signals: [0x1000]
+    period_ms: 100


### PR DESCRIPTION
Part of the larger proton re-architecture [here](https://otto-ra.atlassian.net/wiki/spaces/PFT/pages/344948755/Proton+Reorganization+and+Core+Library) (internal CPR/OTTO employee eyes only 👀 )

This is the final piece of the puzzle for running proton on OTTO robots. OTTO currently uses a centralized task that manages timeouts for all periodic messages. This will allow for a clean API to handle these periodic messages without a bunch of timestamps floating around.