### PR TITLE
FIX: Add extra compilation flags to catch warnings and errors for testing

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -142,6 +142,7 @@
     "Txps",
     "txps",
     "venv",
+    "Werror",
     "Wextra",
     "Wpedantic"
   ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,7 @@ jobs:
         run: |
           cmake -S ./core -B build_core \
             -DCMAKE_BUILD_TYPE=Debug \
+            -DPROTON_BUILD_TESTS=ON \
             -DPROTON_ENABLE_TEST_COVERAGE=ON
 
       - name: Build

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -4,10 +4,13 @@ project(proton_core C CXX)
 # Code coverage instrumentation option
 option(PROTON_ENABLE_TEST_COVERAGE "Enable code coverage instrumentation" OFF)
 
-if(PROTON_ENABLE_TEST_COVERAGE)
-  message(STATUS "Code coverage instrumentation enabled for proton_core")
-  add_compile_options(-fprofile-arcs -ftest-coverage)
-  add_link_options(--coverage)
+if (PROTON_BUILD_TESTS)
+  add_compile_options(-Werror -Wall -Wextra)
+  if(PROTON_ENABLE_TEST_COVERAGE)
+    message(STATUS "Code coverage instrumentation enabled for proton_core")
+    add_compile_options(-fprofile-arcs -ftest-coverage)
+    add_link_options(--coverage)
+  endif()
 endif()
 
 # protobuf v*.23.0+ will fail to find Abseil, which is a required dependency.
@@ -247,169 +250,172 @@ if (PROTON_INSTALL)
 endif()
 
 # Testing
-enable_testing()
-find_package(GTest REQUIRED)
+if (PROTON_BUILD_TESTS)
+  enable_testing()
+  find_package(GTest REQUIRED)
 
-# autogen registry for tests
-set(GENERATED_REGISTRY_FILES
-  "${GENERATED_FOLDER}/target_registry.c"
-  "${GENERATED_FOLDER}/target_node.c"
-  "${GENERATED_FOLDER}/target_registry_ids.h"
-  "${GENERATED_FOLDER}/target_registry_sizes.h"
-  "${GENERATED_FOLDER}/target_connections.h"
-)
+  # autogen registry for tests
+  set(GENERATED_REGISTRY_FILES
+    "${GENERATED_FOLDER}/target_registry.c"
+    "${GENERATED_FOLDER}/target_node.c"
+    "${GENERATED_FOLDER}/target_registry_ids.h"
+    "${GENERATED_FOLDER}/target_registry_sizes.h"
+    "${GENERATED_FOLDER}/target_connections.h"
+  )
 
-proton_core_generator(
-  "${GENERATED_REGISTRY_FILES}"
-  ${GENERATED_FOLDER}
-  "producer"
-  CONFIG_FILE ${CMAKE_CURRENT_SOURCE_DIR}/tests/core/test.yaml
-)
+  proton_core_generator(
+    "${GENERATED_REGISTRY_FILES}"
+    ${GENERATED_FOLDER}
+    "producer"
+    CONFIG_FILE ${CMAKE_CURRENT_SOURCE_DIR}/tests/core/test.yaml
+  )
 
-add_executable(registry_test
-  tests/core/registry_test.cpp
-  ${GENERATED_REGISTRY_FILES}
-)
+  add_executable(registry_test
+    tests/core/registry_test.cpp
+    ${GENERATED_REGISTRY_FILES}
+  )
 
-target_link_libraries(registry_test PUBLIC
-  GTest::gtest_main
-  proton::proton_core
-)
+  target_link_libraries(registry_test PUBLIC
+    GTest::gtest_main
+    proton::proton_core
+  )
 
-target_include_directories(registry_test PUBLIC
-  ${GENERATED_FOLDER}
-  ${CMAKE_CURRENT_SOURCE_DIR}/tests/core
-)
+  target_include_directories(registry_test PUBLIC
+    ${GENERATED_FOLDER}
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/core
+  )
 
-add_executable(encode_decode_test
-  tests/core/encode_decode_test.cpp
-  ${GENERATED_REGISTRY_FILES}
-)
+  add_executable(encode_decode_test
+    tests/core/encode_decode_test.cpp
+    ${GENERATED_REGISTRY_FILES}
+  )
 
-target_link_libraries(encode_decode_test PUBLIC
-  GTest::gtest_main
-  proton::proton_core
-)
+  target_link_libraries(encode_decode_test PUBLIC
+    GTest::gtest_main
+    proton::proton_core
+  )
 
-target_include_directories(encode_decode_test PUBLIC
-  ${GENERATED_FOLDER}
-  ${CMAKE_CURRENT_SOURCE_DIR}/tests/core
-)
+  target_include_directories(encode_decode_test PUBLIC
+    ${GENERATED_FOLDER}
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/core
+  )
 
-add_executable(serial_transport_test
-  tests/core/serial_transport_test.cpp
-  ${GENERATED_REGISTRY_FILES}
-)
+  add_executable(serial_transport_test
+    tests/core/serial_transport_test.cpp
+    ${GENERATED_REGISTRY_FILES}
+  )
 
-target_link_libraries(serial_transport_test PUBLIC
-  GTest::gtest_main
-  proton::proton_core
-)
+  target_link_libraries(serial_transport_test PUBLIC
+    GTest::gtest_main
+    proton::proton_core
+  )
 
-target_include_directories(serial_transport_test PUBLIC
-  ${GENERATED_FOLDER}
-  ${CMAKE_CURRENT_SOURCE_DIR}/tests/core
-)
+  target_include_directories(serial_transport_test PUBLIC
+    ${GENERATED_FOLDER}
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/core
+  )
 
-add_executable(udp4_transport_test
-  tests/core/udp4_transport_test.cpp
-  ${GENERATED_REGISTRY_FILES}
-)
+  add_executable(udp4_transport_test
+    tests/core/udp4_transport_test.cpp
+    ${GENERATED_REGISTRY_FILES}
+  )
 
-target_link_libraries(udp4_transport_test PUBLIC
-  GTest::gtest_main
-  proton::proton_core
-)
+  target_link_libraries(udp4_transport_test PUBLIC
+    GTest::gtest_main
+    proton::proton_core
+  )
 
-target_include_directories(udp4_transport_test PUBLIC
-  ${GENERATED_FOLDER}
-  ${CMAKE_CURRENT_SOURCE_DIR}/tests/core
-)
+  target_include_directories(udp4_transport_test PUBLIC
+    ${GENERATED_FOLDER}
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/core
+  )
 
-add_executable(node_manager_test
-  tests/core/node_manager_test.cpp
-  ${GENERATED_REGISTRY_FILES}
-)
+  add_executable(node_manager_test
+    tests/core/node_manager_test.cpp
+    ${GENERATED_REGISTRY_FILES}
+  )
 
-target_link_libraries(node_manager_test PUBLIC
-  GTest::gtest_main
-  proton::proton_core
-)
+  target_link_libraries(node_manager_test PUBLIC
+    GTest::gtest_main
+    proton::proton_core
+  )
 
-target_include_directories(node_manager_test PUBLIC
-  ${GENERATED_FOLDER}
-  ${CMAKE_CURRENT_SOURCE_DIR}/tests/core
-)
+  target_include_directories(node_manager_test PUBLIC
+    ${GENERATED_FOLDER}
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/core
+  )
 
-set(MULTI_NODE_GENERATED_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/tests/multi_node_generated)
+  set(MULTI_NODE_GENERATED_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/tests/multi_node_generated)
 
-set(MULTI_NODE_GENERATED_REGISTRY_FILES
-  "${MULTI_NODE_GENERATED_FOLDER}/target_registry.c"
-  "${MULTI_NODE_GENERATED_FOLDER}/target_node.c"
-  "${MULTI_NODE_GENERATED_FOLDER}/target_registry_ids.h"
-  "${MULTI_NODE_GENERATED_FOLDER}/target_registry_sizes.h"
-  "${MULTI_NODE_GENERATED_FOLDER}/target_connections.h"
-)
+  set(MULTI_NODE_GENERATED_REGISTRY_FILES
+    "${MULTI_NODE_GENERATED_FOLDER}/target_registry.c"
+    "${MULTI_NODE_GENERATED_FOLDER}/target_node.c"
+    "${MULTI_NODE_GENERATED_FOLDER}/target_registry_ids.h"
+    "${MULTI_NODE_GENERATED_FOLDER}/target_registry_sizes.h"
+    "${MULTI_NODE_GENERATED_FOLDER}/target_connections.h"
+  )
 
-proton_core_generator(
-  "${MULTI_NODE_GENERATED_REGISTRY_FILES}"
-  ${MULTI_NODE_GENERATED_FOLDER}
-  "node1"
-  CONFIG_FILE ${CMAKE_CURRENT_SOURCE_DIR}/tests/core/multi_node_test.yaml
-)
+  proton_core_generator(
+    "${MULTI_NODE_GENERATED_REGISTRY_FILES}"
+    ${MULTI_NODE_GENERATED_FOLDER}
+    "node1"
+    CONFIG_FILE ${CMAKE_CURRENT_SOURCE_DIR}/tests/core/multi_node_test.yaml
+  )
 
-add_executable(multi_node_test
-  tests/core/multi_node_test.cpp
-  ${MULTI_NODE_GENERATED_REGISTRY_FILES}
-)
+  add_executable(multi_node_test
+    tests/core/multi_node_test.cpp
+    ${MULTI_NODE_GENERATED_REGISTRY_FILES}
+  )
 
-target_link_libraries(multi_node_test PUBLIC
-  GTest::gtest_main
-  proton::proton_core
-)
+  target_link_libraries(multi_node_test PUBLIC
+    GTest::gtest_main
+    proton::proton_core
+  )
 
-target_include_directories(multi_node_test PUBLIC
-  ${MULTI_NODE_GENERATED_FOLDER}
-  ${CMAKE_CURRENT_SOURCE_DIR}/tests/core
-)
+  target_include_directories(multi_node_test PUBLIC
+    ${MULTI_NODE_GENERATED_FOLDER}
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/core
+  )
 
-set(PERIODIC_BUNDLE_TEST ${CMAKE_CURRENT_BINARY_DIR}/tests/periodic_bundle_generated)
+  set(PERIODIC_BUNDLE_TEST ${CMAKE_CURRENT_BINARY_DIR}/tests/periodic_bundle_generated)
 
-set(PERIODIC_BUNDLE_GENERATED_REGISTRY_FILES
-  "${PERIODIC_BUNDLE_TEST}/target_registry.c"
-  "${PERIODIC_BUNDLE_TEST}/target_node.c"
-  "${PERIODIC_BUNDLE_TEST}/target_registry_ids.h"
-  "${PERIODIC_BUNDLE_TEST}/target_registry_sizes.h"
-  "${PERIODIC_BUNDLE_TEST}/target_connections.h"
-)
+  set(PERIODIC_BUNDLE_GENERATED_REGISTRY_FILES
+    "${PERIODIC_BUNDLE_TEST}/target_registry.c"
+    "${PERIODIC_BUNDLE_TEST}/target_node.c"
+    "${PERIODIC_BUNDLE_TEST}/target_registry_ids.h"
+    "${PERIODIC_BUNDLE_TEST}/target_registry_sizes.h"
+    "${PERIODIC_BUNDLE_TEST}/target_connections.h"
+  )
 
-proton_core_generator(
-  "${PERIODIC_BUNDLE_GENERATED_REGISTRY_FILES}"
-  ${PERIODIC_BUNDLE_TEST}
-  "producer"
-  CONFIG_FILE ${CMAKE_CURRENT_SOURCE_DIR}/tests/core/periodic_bundle_test.yaml
-)
+  proton_core_generator(
+    "${PERIODIC_BUNDLE_GENERATED_REGISTRY_FILES}"
+    ${PERIODIC_BUNDLE_TEST}
+    "producer"
+    CONFIG_FILE ${CMAKE_CURRENT_SOURCE_DIR}/tests/core/periodic_bundle_test.yaml
+  )
 
-add_executable(periodic_bundle_test
-  tests/core/periodic_bundle_test.cpp
-  ${PERIODIC_BUNDLE_GENERATED_REGISTRY_FILES}
-)
+  add_executable(periodic_bundle_test
+    tests/core/periodic_bundle_test.cpp
+    ${PERIODIC_BUNDLE_GENERATED_REGISTRY_FILES}
+  )
 
-target_link_libraries(periodic_bundle_test PUBLIC
-  GTest::gtest_main
-  proton::proton_core
-)
+  target_link_libraries(periodic_bundle_test PUBLIC
+    GTest::gtest_main
+    proton::proton_core
+  )
 
-target_include_directories(periodic_bundle_test PUBLIC
-  ${PERIODIC_BUNDLE_TEST}
-  ${CMAKE_CURRENT_SOURCE_DIR}/tests/core
-)
+  target_include_directories(periodic_bundle_test PUBLIC
+    ${PERIODIC_BUNDLE_TEST}
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/core
+  )
 
-include(GoogleTest)
-gtest_discover_tests(registry_test)
-gtest_discover_tests(encode_decode_test)
-gtest_discover_tests(serial_transport_test)
-gtest_discover_tests(udp4_transport_test)
-gtest_discover_tests(node_manager_test)
-gtest_discover_tests(multi_node_test)
-gtest_discover_tests(periodic_bundle_test)
+  include(GoogleTest)
+  gtest_discover_tests(registry_test)
+  gtest_discover_tests(encode_decode_test)
+  gtest_discover_tests(serial_transport_test)
+  gtest_discover_tests(udp4_transport_test)
+  gtest_discover_tests(node_manager_test)
+  gtest_discover_tests(multi_node_test)
+  gtest_discover_tests(periodic_bundle_test)
+
+endif()

--- a/core/src/encode_decode.c
+++ b/core/src/encode_decode.c
@@ -232,6 +232,8 @@ static bool proton_decode_bundle_cb(pb_istream_t * istream, const pb_field_t * f
 static bool proton_operation_decode_cb(
   pb_istream_t * istream, const pb_field_t * field, void ** arg)
 {
+  (void)istream;
+
   if (!field || !arg)
   {
     return false;

--- a/core/src/node_manager.c
+++ b/core/src/node_manager.c
@@ -155,7 +155,6 @@ proton_status_e proton_node_update(
 
   bool something_to_send = false;
 
-  uint32_t bundle_to_send = 0;
   uint64_t most_overdue_ms = 0;
   bool send_now_flag = false;
   size_t slot_id = 0;
@@ -181,7 +180,6 @@ proton_status_e proton_node_update(
       if (!send_now_flag)
       {
         send_now_flag = true;
-        bundle_to_send = bundle_desc->bundle_id;
         most_overdue_ms = candidate_overdue;
         slot_id = i;
         something_to_send = true;
@@ -189,7 +187,6 @@ proton_status_e proton_node_update(
       // Check if this triggered bundle is more overdue than our current candidate triggered bundle
       else if (candidate_overdue >= most_overdue_ms)
       {
-        bundle_to_send = bundle_desc->bundle_id;
         most_overdue_ms = candidate_overdue;
         slot_id = i;
         something_to_send = true;
@@ -207,7 +204,6 @@ proton_status_e proton_node_update(
         {
           if (candidate_overdue >= most_overdue_ms)
           {
-            bundle_to_send = bundle_desc->bundle_id;
             most_overdue_ms = candidate_overdue;
             slot_id = i;
             something_to_send = true;

--- a/core/tests/core/encode_decode_test.cpp
+++ b/core/tests/core/encode_decode_test.cpp
@@ -213,8 +213,6 @@ TEST(EncodeDecode, RoundTripMutatedDoubleValue)
   ASSERT_EQ(proton_decode(&registry, raw, bytes_encoded, &decoded_msg), PROTON_OK);
 
   double decoded = 0.0;
-  size_t len = sizeof(decoded);
-  proton_signal_type_e type;
   status = proton_signal_get_double(&registry, PROTON_SIGNAL_DEFAULT_DOUBLE_ID, &decoded);
   ASSERT_EQ(status, PROTON_OK);
   EXPECT_DOUBLE_EQ(decoded, new_value);
@@ -258,7 +256,6 @@ TEST(EncodeDecode, SignalSharedBetweenBundles)
   ASSERT_EQ(proton_decode(&registry, raw, bytes_encoded, &decoded_msg), PROTON_OK);
 
   int32_t decoded = 0;
-  size_t len = sizeof(decoded);
   status = proton_signal_get_int32(&registry, PROTON_SIGNAL_SHARED_SIGNAL_ID, &decoded);
   ASSERT_EQ(status, PROTON_OK);
   EXPECT_EQ(decoded, first_value);


### PR DESCRIPTION
Found when building proton_core with OTTO firmware