### PR TITLE
FIX: Target nodes generating bundles and signals not for them

### DIFF
--- a/core/generator_scripts/generator.py
+++ b/core/generator_scripts/generator.py
@@ -145,9 +145,12 @@ def main():
     set_producer_consumer_ids(config['bundles'], config['nodes'])
     set_bundle_periods(config['bundles'])
 
-    (config['bundles'], config['signals']) = filter_for_target(
-        config['bundles'], config['signals'], config['connections'], target
-    )
+    try:
+        config['bundles'], config['signals'] = filter_for_target(
+            config['bundles'], config['signals'], target
+        )
+    except KeyError as e:
+        raise KeyError(f'Could not find key in config: {e}') from e
 
     generate(
         dest_path,

--- a/core/generator_scripts/generator.py
+++ b/core/generator_scripts/generator.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from config import validate_ids
 from jinja2 import Template
 from normalize import (
+    filter_for_target,
     normalize_signals,
     set_bundle_periods,
     set_node_endpoint_address,
@@ -143,6 +144,10 @@ def main():
     normalize_signals(config['signals'])
     set_producer_consumer_ids(config['bundles'], config['nodes'])
     set_bundle_periods(config['bundles'])
+
+    (config['bundles'], config['signals']) = filter_for_target(
+        config['bundles'], config['signals'], config['connections'], target
+    )
 
     generate(
         dest_path,

--- a/core/generator_scripts/normalize.py
+++ b/core/generator_scripts/normalize.py
@@ -131,7 +131,7 @@ def set_bundle_periods(bundles: list[dict]):
 
 
 def filter_for_target(
-    bundles: list[dict], signals: list[dict], connections: list[dict], target: str
+    bundles: list[dict], signals: list[dict], target: str
 ) -> tuple[list[dict], list[dict]]:
     """
     Filter out all signals and bundles that a target does not care about.
@@ -139,7 +139,6 @@ def filter_for_target(
     Args:
         bundles: "bundles" stanza in proton config
         signals: "signals" stanza in proton config
-        connections: "connections" stanza in proton config
         target: name of node being generated
 
     Returns:

--- a/core/generator_scripts/normalize.py
+++ b/core/generator_scripts/normalize.py
@@ -146,13 +146,6 @@ def filter_for_target(
         tuple of bundles and signals that the target cares about
 
     """
-    peers = {target}
-    for connection in connections:
-        if connection['first']['node'] == target:
-            peers.add(connection['second']['node'])
-        elif connection['second']['node'] == target:
-            peers.add(connection['first']['node'])
-
     filtered_bundles = [
         bundle
         for bundle in bundles

--- a/core/generator_scripts/normalize.py
+++ b/core/generator_scripts/normalize.py
@@ -128,3 +128,40 @@ def set_bundle_periods(bundles: list[dict]):
     """
     for bundle in bundles:
         bundle.setdefault('period_ms', 0)
+
+
+def filter_for_target(
+    bundles: list[dict], signals: list[dict], connections: list[dict], target: str
+) -> tuple[list[dict], list[dict]]:
+    """
+    Filter out all signals and bundles that a target does not care about.
+
+    Args:
+        bundles: "bundles" stanza in proton config
+        signals: "signals" stanza in proton config
+        connections: "connections" stanza in proton config
+        target: name of node being generated
+
+    Returns:
+        tuple of bundles and signals that the target cares about
+
+    """
+    peers = {target}
+    for connection in connections:
+        if connection['first']['node'] == target:
+            peers.add(connection['second']['node'])
+        elif connection['second']['node'] == target:
+            peers.add(connection['first']['node'])
+
+    filtered_bundles = [
+        bundle
+        for bundle in bundles
+        if target in bundle['producers'] or target in bundle['consumers']
+    ]
+    filtered_signal_ids = set()
+    for bundle in filtered_bundles:
+        filtered_signal_ids.update(bundle['signals'])
+
+    filtered_signals = [signal for signal in signals if signal['id'] in filtered_signal_ids]
+
+    return (filtered_bundles, filtered_signals)

--- a/core/tests/core/registry_test.cpp
+++ b/core/tests/core/registry_test.cpp
@@ -65,6 +65,17 @@ TEST(SignalRegistry, GetSignalInvalidId)
   free(registry.signal_registry);
 }
 
+TEST(SignalRegistry, GetSignalIdNotInTarget)
+{
+  // Signal ID 0x1111 is defined in test.yaml, but it is not part of any bundle that
+  // the test producer is part of.
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  signal_desc_t * desc = proton_registry_get_signal(&registry, 0x1111, NULL);
+  bool found = desc != nullptr;
+  EXPECT_FALSE(found);
+  free(registry.signal_registry);
+}
+
 TEST(SignalRegistry, GetScalarSignalValue)
 {
   proton_registry_t registry = copy_default_registry(&g_proton_registry);

--- a/core/tests/core/test.yaml
+++ b/core/tests/core/test.yaml
@@ -13,10 +13,23 @@ nodes:
         type: udp4
         ip: 127.0.0.1
         port: 11417
+      - id: 1
+        type: udp4
+        ip: 127.0.0.1
+        port: 11418
+  - name: unused_consumer
+    id: 2
+    endpoints:
+      - id: 0
+        type: udp4
+        ip: 127.0.0.1
+        port: 11419
 
 connections:
   - first: {node: producer, id: 0}
     second: {node: consumer, id: 0}
+  - first: {node: consumer, id: 1}
+    second: {node: unused_consumer, id: 0}
 
 signals:
   - {name: double_value, id: 0x1000, type: double}
@@ -34,6 +47,7 @@ signals:
   - {name: really_long_string, id: 0x1013, type: string, value: "ipsumsedolorsitametconsecteturadipiscingelit", capacity: 44}
   - {name: really_long_bytes, id: 0x1014, type: bytes, value: [0, 1, 2, 3, 4, 5, 6, 7], capacity: 8}
   - {name: shared_signal, id: 0x1015, type: int32}
+  - {name: unused_signal, id: 0x1111, type: float}
 
 bundles:
   - name: value_test
@@ -66,3 +80,15 @@ bundles:
     consumers: [consumer]
     signals: [0x1000]
     period_ms: 100
+
+  - name: really_long_values_test
+    id: 0x105
+    producers: [producer]
+    consumers: [consumer]
+    signals: [0x1013, 0x1014]
+
+  - name: unused_bundle
+    id: 0x1112
+    producers: [consumer]
+    consumers: [unused_consumer]
+    signals: [0x1111]


### PR DESCRIPTION
Filter out bundles and signals that are part of peer connections that the target doesn't partake in