### PR TITLE
Feature: CORE-37263 registry cpp wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,8 @@ jobs:
           cmake -S ./cpp -B build_core \
             -DCMAKE_BUILD_TYPE=Debug \
             -DPROTON_BUILD_TESTS=ON \
-            -DPROTON_ENABLE_TEST_COVERAGE=ON
+            -DPROTON_ENABLE_TEST_COVERAGE=ON \
+            -DPROTON_ENABLE_ALLOC=ON
 
       - name: Build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -S ./core -B build_core \
+          cmake -S ./cpp -B build_core \
             -DCMAKE_BUILD_TYPE=Debug \
             -DPROTON_BUILD_TESTS=ON \
             -DPROTON_ENABLE_TEST_COVERAGE=ON

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -214,7 +214,7 @@ if(PROTON_BUILD_TESTS)
   find_package(GTest REQUIRED)
   include(${CMAKE_CURRENT_LIST_DIR}/../cmake/protonCoreGenerator.cmake)
 
-# autogen registry for tests
+  # autogen registry for tests
   set(GENERATED_REGISTRY_FILES
     "${GENERATED_FOLDER}/target_registry.c"
     "${GENERATED_FOLDER}/target_node.c"

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -148,12 +148,9 @@ add_custom_target(generate_protoc ALL
 # -------------------------------
 set(GENERATED_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/tests/generated)
 
-
 # -------------------------------
 # proton_core library
 # -------------------------------
-option(PROTON_DEBUG "Enable PROTON_DEBUG preprocessor macro" OFF)
-
 set(PROTON_COMMON_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
 add_library(${PROJECT_NAME}
@@ -170,10 +167,6 @@ add_library(${PROJECT_NAME}
 )
 
 add_dependencies(${PROJECT_NAME} generate_protoc)
-
-if (PROTON_DEBUG)
-  target_compile_definitions(proton_core PUBLIC PROTON_DEBUG)
-endif()
 
 target_include_directories(proton_core PUBLIC ${GENERATED_FOLDER} ../include)
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -4,6 +4,7 @@ project(proton_core C CXX)
 # Code coverage instrumentation option
 option(PROTON_BUILD_TESTS "Build unit tests" ON)
 option(PROTON_ENABLE_TEST_COVERAGE "Enable code coverage instrumentation" OFF)
+option(PROTON_ENABLE_ALLOC "Enable heap allocation and exceptions" OFF)
 
 if (PROTON_BUILD_TESTS)
   add_compile_options(-Werror -Wall -Wextra)
@@ -165,6 +166,10 @@ add_library(${PROJECT_NAME}
   ${nanopb_SOURCE_DIR}/pb_encode.c
   ${NANOPB_GENERATED_SRCS}
 )
+
+if(PROTON_ENABLE_ALLOC)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC PROTON_ENABLE_ALLOC=1)
+endif()
 
 add_dependencies(${PROJECT_NAME} generate_protoc)
 

--- a/core/include/proton/proton_config.h
+++ b/core/include/proton/proton_config.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Rockwell Automation Technologies, Inc., All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Tom Wallis (thomas.wallis@rockwellautomation.com)
+ */
+
+#ifndef PROTON_CONFIG_HPP
+#define PROTON_CONFIG_HPP
+
+// Default to embedded mode (no allocation/RTTI) if not specified
+#ifndef PROTON_ENABLE_ALLOC
+#define PROTON_ENABLE_ALLOC 0
+#endif
+
+#endif  // PROTON_CONFIG_HPP

--- a/core/include/proton/registry.h
+++ b/core/include/proton/registry.h
@@ -28,6 +28,7 @@
 #include "proton_core/signal.pb.h"
 
 #include "proton/common.h"
+#include "proton/proton_config.h"
 
 #ifdef __cplusplus
 extern "C"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -86,6 +86,20 @@ if (PROTON_BUILD_TESTS)
     ${CMAKE_CURRENT_SOURCE_DIR}/../core/tests/core
   )
 
+  add_executable(lock_test_cpp
+    tests/lock_test.cpp
+  )
+
+  target_link_libraries(lock_test_cpp PUBLIC
+    GTest::gtest_main
+    proton::proton_core_cpp
+  )
+
+  target_include_directories(lock_test_cpp PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/../core/tests/core
+  )
+
   include(GoogleTest)
   gtest_discover_tests(registry_test_cpp)
+  gtest_discover_tests(lock_test_cpp)
 endif()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -4,7 +4,7 @@ project(proton_core_cpp C CXX)
 # Code coverage instrumentation option
 option(PROTON_BUILD_TESTS "Build unit tests" ON)
 option(PROTON_ENABLE_TEST_COVERAGE "Enable code coverage instrumentation" OFF)
-option(PROTON_ALLOW_ALLOC "Enable heap allocation and exceptions" OFF)
+option(PROTON_ENABLE_ALLOC "Enable heap allocation and exceptions" OFF)
 
 if (PROTON_BUILD_TESTS)
   add_compile_options(-Werror -Wall -Wextra)
@@ -41,8 +41,8 @@ target_link_libraries(${PROJECT_NAME}
     proton::proton_core
 )
 
-if(PROTON_ALLOW_ALLOC)
-  target_compile_definitions(${PROJECT_NAME} PUBLIC PROTON_ALLOW_ALLOC=1)
+if(PROTON_ENABLE_ALLOC)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC PROTON_ENABLE_ALLOC=1)
 else()
   target_compile_options(${PROJECT_NAME} PRIVATE -fno-exceptions -fno-rtti)
 endif()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.14)
+project(proton_core_cpp C CXX)
+
+set(PROTON_COMMON_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+
+# Add proton_core dependency if not already defined
+if(NOT TARGET proton_core)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../core ${CMAKE_CURRENT_BINARY_DIR}/core)
+endif()
+
+add_library(${PROJECT_NAME}
+  src/bundle_access.cpp
+  src/signal_access.cpp
+)
+
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+    $<BUILD_INTERFACE:${PROTON_COMMON_INCLUDE_DIR}>
+)
+
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+    proton::proton_core
+)
+
+add_library(proton::${PROJECT_NAME} ALIAS ${PROJECT_NAME})

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,6 +1,22 @@
 cmake_minimum_required(VERSION 3.14)
 project(proton_core_cpp C CXX)
 
+# Code coverage instrumentation option
+option(PROTON_BUILD_TESTS "Build unit tests" ON)
+option(PROTON_ENABLE_TEST_COVERAGE "Enable code coverage instrumentation" OFF)
+option(PROTON_ALLOW_ALLOC "Enable heap allocation and exceptions" OFF)
+
+if (PROTON_BUILD_TESTS)
+  add_compile_options(-Werror -Wall -Wextra)
+  if(PROTON_ENABLE_TEST_COVERAGE)
+    message(STATUS "Code coverage instrumentation enabled for proton_core")
+    add_compile_options(-fprofile-arcs -ftest-coverage)
+    add_link_options(--coverage)
+  endif()
+elseif(PROTON_ENABLE_TEST_COVERAGE)
+   message(ERROR "Testing must be enabled to build test coverage")
+endif()
+
 set(PROTON_COMMON_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
 # Add proton_core dependency if not already defined
@@ -25,4 +41,51 @@ target_link_libraries(${PROJECT_NAME}
     proton::proton_core
 )
 
+if(PROTON_ALLOW_ALLOC)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC PROTON_ALLOW_ALLOC=1)
+else()
+  target_compile_options(${PROJECT_NAME} PRIVATE -fno-exceptions -fno-rtti)
+endif()
+
 add_library(proton::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+# Testing
+if (PROTON_BUILD_TESTS)
+  enable_testing()
+  find_package(GTest REQUIRED)
+  include(${CMAKE_CURRENT_LIST_DIR}/../cmake/protonCoreGenerator.cmake)
+
+  set(GENERATED_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/tests/generated)
+  set(GENERATED_REGISTRY_FILES
+    "${GENERATED_FOLDER}/target_registry.c"
+    "${GENERATED_FOLDER}/target_node.c"
+    "${GENERATED_FOLDER}/target_registry_ids.h"
+    "${GENERATED_FOLDER}/target_registry_sizes.h"
+    "${GENERATED_FOLDER}/target_connections.h"
+  )
+
+  proton_core_generator(
+    "${GENERATED_REGISTRY_FILES}"
+    ${GENERATED_FOLDER}
+    "producer"
+    CONFIG_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../core/tests/core/test.yaml
+  )
+
+  add_executable(registry_test_cpp
+    tests/registry_test.cpp
+    ${GENERATED_REGISTRY_FILES}
+  )
+
+  target_link_libraries(registry_test_cpp PUBLIC
+    GTest::gtest_main
+    proton::proton_core_cpp
+  )
+
+  target_include_directories(registry_test_cpp PUBLIC
+    ${GENERATED_FOLDER}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../core/tests/core
+  )
+
+  include(GoogleTest)
+  gtest_discover_tests(registry_test_cpp)
+endif()

--- a/cpp/include/protoncpp/bundle_access.hpp
+++ b/cpp/include/protoncpp/bundle_access.hpp
@@ -22,9 +22,16 @@
 #include "proton/common.h"
 #include "proton/registry.h"
 
+#if PROTON_ENABLE_ALLOC
+#include <functional>
+#endif
+
 namespace proton
 {
 
+/**
+ * @class BundleAccess provides access to bundle metadata and state from the proton_core registry API.
+ */
 class BundleAccess
 {
 public:
@@ -40,9 +47,34 @@ public:
   void set_period(uint32_t period_ms) noexcept;
   void set_callback(proton_bundle_cb_f cb, void * ctx) noexcept;
 
+#if PROTON_ENABLE_ALLOC
+  using CallbackType =
+    std::function<void(uint32_t bundle_id, const uint32_t * signal_ids, size_t count)>;
+
+  void set_callback(CallbackType cb) noexcept
+  {
+    // Store the std::function in a heap-allocated wrapper and pass it as the context to the C callback
+    callback_wrapper_ = std::move(cb);
+    set_callback(
+      [](uint32_t bundle_id, const uint32_t * signal_ids, size_t count, void * ctx)
+      {
+        auto * self = static_cast<BundleAccess *>(ctx);
+        if (self->callback_wrapper_)
+        {
+          self->callback_wrapper_(bundle_id, signal_ids, count);
+        }
+      },
+      this);
+  }
+#endif  // PROTON_ENABLE_ALLOC
+
 private:
   proton_registry_t * registry_;
   uint32_t id_;
+
+#if PROTON_ENABLE_ALLOC
+  CallbackType callback_wrapper_ = nullptr;
+#endif  // PROTON_ENABLE_ALLOC
 };
 
 }  // namespace proton

--- a/cpp/include/protoncpp/bundle_access.hpp
+++ b/cpp/include/protoncpp/bundle_access.hpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Rockwell Automation Technologies, Inc., All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Tom Wallis (thomas.wallis@rockwellautomation.com)
+ */
+
+#ifndef PROTON_BUNDLE_HPP
+#define PROTON_BUNDLE_HPP
+
+#include "proton/common.h"
+#include "proton/registry.h"
+
+namespace proton
+{
+
+class BundleAccess
+{
+public:
+  constexpr explicit BundleAccess(proton_registry_t * registry, uint32_t id) noexcept
+  : registry_(reg), id_(id)
+  {
+  }
+
+  uint32_t id() const noexcept { return id_; }
+
+  const bundle_desc_t * descriptor() const noexcept;
+
+  void set_period(uint32_t period_ms) noexcept;
+  void set_callback(proton_bundle_cb_f cb, void * ctx) noexcept;
+
+private:
+  proton_registry_t * registry_;
+  uint32_t id_;
+};
+
+}  // namespace proton
+
+#endif  // PROTON_BUNDLE_HPP

--- a/cpp/include/protoncpp/bundle_access.hpp
+++ b/cpp/include/protoncpp/bundle_access.hpp
@@ -35,7 +35,7 @@ namespace proton
 class BundleAccess
 {
 public:
-  constexpr explicit BundleAccess(proton_registry_t * registry, uint32_t id) noexcept
+  explicit BundleAccess(proton_registry_t * registry, uint32_t id) noexcept
   : registry_(registry), id_(id)
   {
   }

--- a/cpp/include/protoncpp/bundle_access.hpp
+++ b/cpp/include/protoncpp/bundle_access.hpp
@@ -29,7 +29,7 @@ class BundleAccess
 {
 public:
   constexpr explicit BundleAccess(proton_registry_t * registry, uint32_t id) noexcept
-  : registry_(reg), id_(id)
+  : registry_(registry), id_(id)
   {
   }
 

--- a/cpp/include/protoncpp/registry_lock.hpp
+++ b/cpp/include/protoncpp/registry_lock.hpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Rockwell Automation Technologies, Inc., All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Tom Wallis (thomas.wallis@rockwellautomation.com)
+ */
+
+#ifndef PROTON_REGISTRY_LOCK_HPP
+#define PROTON_REGISTRY_LOCK_HPP
+
+#include "proton/registry.h"
+
+namespace proton
+{
+
+class RegistryLock
+{
+public:
+  explicit RegistryLock(const proton_registry_t * registry) noexcept : registry_(registry)
+  {
+    acquired_ = proton_lock_registry(registry_) == PROTON_OK;
+  }
+
+  ~RegistryLock() noexcept
+  {
+    if (acquired_)
+    {
+      proton_unlock_registry(registry_);
+    }
+  }
+
+  RegistryLock(const RegistryLock &) = delete;
+  RegistryLock & operator=(const RegistryLock &) = delete;
+
+  bool ok() const noexcept { return acquired_; }
+
+  explicit operator bool() const noexcept { return acquired_; }
+
+private:
+  const proton_registry_t * registry_;
+  bool acquired_;
+};
+
+}  // namespace proton
+
+#endif  // PROTON_REGISTRY_LOCK_HPP

--- a/cpp/include/protoncpp/registry_lock.hpp
+++ b/cpp/include/protoncpp/registry_lock.hpp
@@ -24,6 +24,28 @@
 namespace proton
 {
 
+/**
+ * @class RegistryLock class for proton_registry_t optional mutex.
+ * For using within std::lock_guard or std::unique_lock
+ */
+class RegistryLock
+{
+public:
+  explicit RegistryLock(const proton_registry_t * registry) noexcept : registry_(registry) {}
+
+  ~RegistryLock() noexcept = default;
+
+  void lock() noexcept { proton_lock_registry(registry_); }
+  void unlock() noexcept { proton_unlock_registry(registry_); }
+
+  RegistryLock(const RegistryLock &) = delete;
+  RegistryLock & operator=(const RegistryLock &) = delete;
+}
+
+/**
+ * @class ScopedLock class for RAII-style locking of proton_registry_t optional mutex.
+ * Automatically releases the lock when going out of scope.
+ */
 class ScopedLock
 {
 public:

--- a/cpp/include/protoncpp/registry_lock.hpp
+++ b/cpp/include/protoncpp/registry_lock.hpp
@@ -40,7 +40,10 @@ public:
 
   RegistryLock(const RegistryLock &) = delete;
   RegistryLock & operator=(const RegistryLock &) = delete;
-}
+
+private:
+  const proton_registry_t * registry_;
+};
 
 /**
  * @class ScopedLock class for RAII-style locking of proton_registry_t optional mutex.

--- a/cpp/include/protoncpp/registry_lock.hpp
+++ b/cpp/include/protoncpp/registry_lock.hpp
@@ -24,15 +24,15 @@
 namespace proton
 {
 
-class RegistryLock
+class ScopedLock
 {
 public:
-  explicit RegistryLock(const proton_registry_t * registry) noexcept : registry_(registry)
+  explicit ScopedLock(const proton_registry_t * registry) noexcept : registry_(registry)
   {
     acquired_ = proton_lock_registry(registry_) == PROTON_OK;
   }
 
-  ~RegistryLock() noexcept
+  ~ScopedLock() noexcept
   {
     if (acquired_)
     {
@@ -40,8 +40,8 @@ public:
     }
   }
 
-  RegistryLock(const RegistryLock &) = delete;
-  RegistryLock & operator=(const RegistryLock &) = delete;
+  ScopedLock(const ScopedLock &) = delete;
+  ScopedLock & operator=(const ScopedLock &) = delete;
 
   bool ok() const noexcept { return acquired_; }
 

--- a/cpp/include/protoncpp/signal_access.hpp
+++ b/cpp/include/protoncpp/signal_access.hpp
@@ -22,14 +22,12 @@
 #include "proton/common.h"
 #include "proton/registry.h"
 
-// Default to embedded mode (no allocation/RTTI) if not specified
-#ifndef PROTON_ENABLE_ALLOC
-#define PROTON_ENABLE_ALLOC 0
-#endif
-
 namespace proton
 {
 
+/**
+ * @class SignalAccess provides type-safe access to signal values from the proton_core registry API.
+ */
 class SignalAccess
 {
 public:
@@ -128,6 +126,10 @@ protected:
   uint32_t id_;
 };
 
+/**
+ * @class Signal typed wrapper around a SignalBase. Does not require RTTI, but if
+ * RTTI is enabled, it can be safely stored as a SignalBase pointer and dynamically cast back to Signal<T>.
+ */
 template <typename T>
 class Signal : public SignalBase
 {

--- a/cpp/include/protoncpp/signal_access.hpp
+++ b/cpp/include/protoncpp/signal_access.hpp
@@ -16,8 +16,8 @@
  * @author Tom Wallis (thomas.wallis@rockwellautomation.com)
  */
 
-#ifndef PROTON_SIGNAL_HPP
-#define PROTON_SIGNAL_HPP
+#ifndef PROTON_SIGNAL_ACCESS_HPP
+#define PROTON_SIGNAL_ACCESS_HPP
 
 #include "proton/common.h"
 #include "proton/registry.h"
@@ -48,16 +48,41 @@ public:
   proton_status_e get(uint32_t id, uint64_t & out) const noexcept;
   proton_status_e set(uint32_t id, uint64_t value) noexcept;
 
-  proton_status_e get_string(uint32_t id, char * buf, size_t cap, size_t & len) const noexcept;
-  proton_status_e set_string(uint32_t id, const char * buf, size_t len) const noexcept;
+  proton_status_e get(uint32_t id, char * buf, size_t cap, size_t & len) const noexcept;
+  proton_status_e set(uint32_t id, const char * buf, size_t len) const noexcept;
 
-  proton_status_e get_bytes(uint32_t id, uint8_t * buf, size_t cap, size_t & len) const noexcept;
-  proton_status_e set_bytes(uint32_t id, const uint8_t * buf, size_t len) const noexcept;
+  proton_status_e get(uint32_t id, uint8_t * buf, size_t cap, size_t & len) const noexcept;
+  proton_status_e set(uint32_t id, const uint8_t * buf, size_t len) const noexcept;
 
 private:
   proton_registry_t * registry_;
 };
 
+template <typename T>
+class Signal
+{
+public:
+  constexpr explicit Signal(proton_registry_t * registry, uint32_t id)
+  : registry_(registry), id_(id)
+  {
+  }
+
+  uint32_t id() const noexcept { return id_; }
+
+  signal_desc_t * desc() const noexcept
+  {
+    return proton_registry_get_signal(registry_, id_, nullptr);
+  }
+
+  proton_status_e get(T & out) const noexcept { return SignalAccess(registry_).get(id_, out); }
+
+  proton_status_e set(T value) noexcept { return SignalAccess(registry_).set(id_, value); }
+
+private:
+  proton_registry_t * registry_;
+  uint32_t id_;
+};
+
 }  // namespace proton
 
-#endif  // PROTON_SIGNAL_HPP
+#endif  // PROTON_SIGNAL_ACCESS_HPP

--- a/cpp/include/protoncpp/signal_access.hpp
+++ b/cpp/include/protoncpp/signal_access.hpp
@@ -28,7 +28,7 @@ namespace proton
 class SignalAccess
 {
 public:
-  constexpr explicit SignalAccess(proton_registry_t * registry) noexcept : registry_(reg) {}
+  constexpr explicit SignalAccess(proton_registry_t * registry) noexcept : registry_(registry) {}
 
   proton_status_e get(uint32_t id, double & out) const noexcept;
   proton_status_e set(uint32_t id, double value) noexcept;

--- a/cpp/include/protoncpp/signal_access.hpp
+++ b/cpp/include/protoncpp/signal_access.hpp
@@ -48,6 +48,9 @@ public:
   proton_status_e get(uint32_t id, uint64_t & out) const noexcept;
   proton_status_e set(uint32_t id, uint64_t value) noexcept;
 
+  proton_status_e get(uint32_t id, bool & out) const noexcept;
+  proton_status_e set(uint32_t id, bool value) noexcept;
+
   proton_status_e get(uint32_t id, char * buf, size_t cap, size_t & len) const noexcept;
   proton_status_e set(uint32_t id, const char * buf, size_t len) const noexcept;
 

--- a/cpp/include/protoncpp/signal_access.hpp
+++ b/cpp/include/protoncpp/signal_access.hpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Rockwell Automation Technologies, Inc., All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Tom Wallis (thomas.wallis@rockwellautomation.com)
+ */
+
+#ifndef PROTON_SIGNAL_HPP
+#define PROTON_SIGNAL_HPP
+
+#include "proton/common.h"
+#include "proton/registry.h"
+
+namespace proton
+{
+
+class SignalAccess
+{
+public:
+  constexpr explicit SignalAccess(proton_registry_t * registry) noexcept : registry_(reg) {}
+
+  proton_status_e get(uint32_t id, double & out) const noexcept;
+  proton_status_e set(uint32_t id, double value) noexcept;
+
+  proton_status_e get(uint32_t id, float & out) const noexcept;
+  proton_status_e set(uint32_t id, float value) noexcept;
+
+  proton_status_e get(uint32_t id, int32_t & out) const noexcept;
+  proton_status_e set(uint32_t id, int32_t value) noexcept;
+
+  proton_status_e get(uint32_t id, int64_t & out) const noexcept;
+  proton_status_e set(uint64_t id, int64_t value) noexcept;
+
+  proton_status_e get(uint32_t id, uint32_t & out) const noexcept;
+  proton_status_e set(uint32_t id, uint32_t value) noexcept;
+
+  proton_status_e get(uint32_t id, uint64_t & out) const noexcept;
+  proton_status_e set(uint32_t id, uint64_t value) noexcept;
+
+  proton_status_e get_string(uint32_t id, char * buf, size_t cap, size_t & len) const noexcept;
+  proton_status_e set_string(uint32_t id, const char * buf, size_t len) const noexcept;
+
+  proton_status_e get_bytes(uint32_t id, uint8_t * buf, size_t cap, size_t & len) const noexcept;
+  proton_status_e set_bytes(uint32_t id, const uint8_t * buf, size_t len) const noexcept;
+
+private:
+  proton_registry_t * registry_;
+};
+
+}  // namespace proton
+
+#endif  // PROTON_SIGNAL_HPP

--- a/cpp/include/protoncpp/signal_access.hpp
+++ b/cpp/include/protoncpp/signal_access.hpp
@@ -22,6 +22,11 @@
 #include "proton/common.h"
 #include "proton/registry.h"
 
+// Default to embedded mode (no allocation/RTTI) if not specified
+#ifndef PROTON_ENABLE_ALLOC
+#define PROTON_ENABLE_ALLOC 0
+#endif
+
 namespace proton
 {
 
@@ -61,14 +66,49 @@ private:
   proton_registry_t * registry_;
 };
 
+/**
+ * Forward-declaration of Signal class for RTTI-enabled purposes
+ */
 template <typename T>
-class Signal
+class Signal;
+
+/**
+ * @brief Non-templated base class for Signal<T>, enabling storage in containers.
+ *
+ * Use type() to determine the actual signal type at runtime.
+ * When PROTON_ENABLE_ALLOC is enabled, use as<T>() for safe dynamic_cast.
+ * When disabled (for embedded applications), cast to Signal<T>* only when type() matches.
+ */
+class SignalBase
 {
 public:
-  constexpr explicit Signal(proton_registry_t * registry, uint32_t id)
+  constexpr SignalBase(proton_registry_t * registry, uint32_t id) noexcept
   : registry_(registry), id_(id)
   {
   }
+
+#if PROTON_ENABLE_ALLOC
+  virtual ~SignalBase() = default;
+
+  /**
+   * @brief Safely cast to Signal<T>* using dynamic_cast (requires RTTI).
+   * @return Pointer to Signal<T> if type matches, nullptr otherwise.
+   */
+  template <typename T>
+  Signal<T> * as() noexcept
+  {
+    return dynamic_cast<Signal<T> *>(this);
+  }
+
+  template <typename T>
+  const Signal<T> * as() const noexcept
+  {
+    return dynamic_cast<const Signal<T> *>(this);
+  }
+#else
+  // No virtual destructor in embedded mode (no RTTI)
+  ~SignalBase() = default;
+#endif
 
   uint32_t id() const noexcept { return id_; }
 
@@ -77,13 +117,26 @@ public:
     return proton_registry_get_signal(registry_, id_, nullptr);
   }
 
+  proton_signal_type_e type() const noexcept
+  {
+    signal_desc_t * d = desc();
+    return d ? d->type : PROTON_INVALID_TYPE;
+  }
+
+protected:
+  proton_registry_t * registry_;
+  uint32_t id_;
+};
+
+template <typename T>
+class Signal : public SignalBase
+{
+public:
+  constexpr explicit Signal(proton_registry_t * registry, uint32_t id) : SignalBase(registry, id) {}
+
   proton_status_e get(T & out) const noexcept { return SignalAccess(registry_).get(id_, out); }
 
   proton_status_e set(T value) noexcept { return SignalAccess(registry_).set(id_, value); }
-
-private:
-  proton_registry_t * registry_;
-  uint32_t id_;
 };
 
 }  // namespace proton

--- a/cpp/include/protoncpp/signal_access.hpp
+++ b/cpp/include/protoncpp/signal_access.hpp
@@ -40,7 +40,7 @@ public:
   proton_status_e set(uint32_t id, int32_t value) noexcept;
 
   proton_status_e get(uint32_t id, int64_t & out) const noexcept;
-  proton_status_e set(uint64_t id, int64_t value) noexcept;
+  proton_status_e set(uint32_t id, int64_t value) noexcept;
 
   proton_status_e get(uint32_t id, uint32_t & out) const noexcept;
   proton_status_e set(uint32_t id, uint32_t value) noexcept;

--- a/cpp/include/protoncpp/signal_access.hpp
+++ b/cpp/include/protoncpp/signal_access.hpp
@@ -22,6 +22,10 @@
 #include "proton/common.h"
 #include "proton/registry.h"
 
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
 namespace proton
 {
 
@@ -139,6 +143,36 @@ public:
   proton_status_e get(T & out) const noexcept { return SignalAccess(registry_).get(id_, out); }
 
   proton_status_e set(T value) noexcept { return SignalAccess(registry_).set(id_, value); }
+
+  proton_status_e get(char * buf, size_t cap, size_t & len) const noexcept
+  {
+    static_assert(
+      std::is_same_v<T, char *>, "get(char*, size_t, size_t&) is only valid for Signal<char*>");
+    return SignalAccess(registry_).get(id_, buf, cap, len);
+  }
+
+  proton_status_e set(const char * buf, size_t len) noexcept
+  {
+    static_assert(
+      std::is_same_v<T, char *>, "set(const char*, size_t) is only valid for Signal<char*>");
+    return SignalAccess(registry_).set(id_, buf, len);
+  }
+
+  proton_status_e get(uint8_t * buf, size_t cap, size_t & len) const noexcept
+  {
+    static_assert(
+      std::is_same_v<T, uint8_t *>,
+      "get(uint8_t*, size_t, size_t&) is only valid for Signal<uint8_t*>");
+    return SignalAccess(registry_).get(id_, buf, cap, len);
+  }
+
+  proton_status_e set(const uint8_t * buf, size_t len) noexcept
+  {
+    static_assert(
+      std::is_same_v<T, uint8_t *>,
+      "set(const uint8_t*, size_t) is only valid for Signal<uint8_t*>");
+    return SignalAccess(registry_).set(id_, buf, len);
+  }
 };
 
 }  // namespace proton

--- a/cpp/src/bundle_access.cpp
+++ b/cpp/src/bundle_access.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Rockwell Automation Technologies, Inc., All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Tom Wallis (thomas.wallis@rockwellautomation.com)
+ */
+
+#include "protoncpp/bundle_access.hpp"
+
+namespace proton
+{
+
+const bundle_desc_t * BundleAccess::descriptor() const noexcept
+{
+  return proton_registry_get_bundle(registry_, id_, nullptr);
+}
+
+void BundleAccess::set_period(uint32_t period_ms) noexcept
+{
+  proton_registry_set_bundle_period(registry_, id_, period_ms);
+}
+
+void BundleAccess::set_callback(proton_bundle_cb_f cb, void * ctx) noexcept
+{
+  proton_registry_set_bundle_callback(registry_, id_, cb, ctx);
+}
+
+}  // namespace proton

--- a/cpp/src/signal_access.cpp
+++ b/cpp/src/signal_access.cpp
@@ -75,6 +75,15 @@ proton_status_e SignalAccess::set(uint32_t id, uint64_t value) noexcept
   return proton_signal_set_uint64(registry_, id, value);
 }
 
+proton_status_e SignalAccess::get(uint32_t id, bool & out) const noexcept
+{
+  return proton_signal_get_bool(registry_, id, &out);
+}
+proton_status_e SignalAccess::set(uint32_t id, bool value) noexcept
+{
+  return proton_signal_set_bool(registry_, id, value);
+}
+
 proton_status_e SignalAccess::get(uint32_t id, char * buf, size_t cap, size_t & len) const noexcept
 {
   return proton_signal_get_string(registry_, id, buf, cap, &len);

--- a/cpp/src/signal_access.cpp
+++ b/cpp/src/signal_access.cpp
@@ -27,7 +27,7 @@ proton_status_e SignalAccess::get(uint32_t id, double & out) const noexcept
 }
 proton_status_e SignalAccess::set(uint32_t id, double value) noexcept
 {
-  return proton_signal_set_double(registry, id, value);
+  return proton_signal_set_double(registry_, id, value);
 }
 
 proton_status_e SignalAccess::get(uint32_t id, float & out) const noexcept
@@ -36,7 +36,7 @@ proton_status_e SignalAccess::get(uint32_t id, float & out) const noexcept
 }
 proton_status_e SignalAccess::set(uint32_t id, float value) noexcept
 {
-  return proton_signal_set_float(registry, id, value);
+  return proton_signal_set_float(registry_, id, value);
 }
 
 proton_status_e SignalAccess::get(uint32_t id, int32_t & out) const noexcept
@@ -45,7 +45,7 @@ proton_status_e SignalAccess::get(uint32_t id, int32_t & out) const noexcept
 }
 proton_status_e SignalAccess::set(uint32_t id, int32_t value) noexcept
 {
-  return proton_signal_set_int32(registry, id, value);
+  return proton_signal_set_int32(registry_, id, value);
 }
 
 proton_status_e SignalAccess::get(uint32_t id, int64_t & out) const noexcept
@@ -54,7 +54,7 @@ proton_status_e SignalAccess::get(uint32_t id, int64_t & out) const noexcept
 }
 proton_status_e SignalAccess::set(uint64_t id, int64_t value) noexcept
 {
-  return proton_signal_set_int64(registry, id, value);
+  return proton_signal_set_int64(registry_, id, value);
 }
 
 proton_status_e SignalAccess::get(uint32_t id, uint32_t & out) const noexcept
@@ -63,7 +63,7 @@ proton_status_e SignalAccess::get(uint32_t id, uint32_t & out) const noexcept
 }
 proton_status_e SignalAccess::set(uint32_t id, uint32_t value) noexcept
 {
-  return proton_signal_set_uint32(registry, id, value);
+  return proton_signal_set_uint32(registry_, id, value);
 }
 
 proton_status_e SignalAccess::get(uint32_t id, uint64_t & out) const noexcept
@@ -72,21 +72,27 @@ proton_status_e SignalAccess::get(uint32_t id, uint64_t & out) const noexcept
 }
 proton_status_e SignalAccess::set(uint32_t id, uint64_t value) noexcept
 {
-  return proton_signal_set_uint64(registry, id, value);
+  return proton_signal_set_uint64(registry_, id, value);
 }
 
-proton_status_e SignalAccess::get_string(uint32_t id, char * buf, size_t cap, size_t & len)
-  const noexcept {return proton_signal_get_string(registry, id, buf, cap, &len)} proton_status_e
-  SignalAccess::set_string(uint32_t id, const char * buf, size_t len) const noexcept {
-    return proton_signal_set_string(registry, id, buf, len)}
-
-proton_status_e SignalAccess::get_bytes(uint32_t id, uint8_t * buf, size_t cap, size_t & len)
-  const noexcept {return proton_signal_get_bytes(registry, id, buf, cap, &len)} proton_status_e
-  SignalAccess::set_bytes(uint32_t id, const uint8_t * buf, size_t len) const noexcept
+proton_status_e SignalAccess::get_string(
+  uint32_t id, char * buf, size_t cap, size_t & len) const noexcept
 {
-  return proton_signal_set_bytes(registry, id, buf, len)
+  return proton_signal_get_string(registry_, id, buf, cap, &len);
+}
+proton_status_e SignalAccess::set_string(uint32_t id, const char * buf, size_t len) const noexcept
+{
+  return proton_signal_set_string(registry_, id, buf, len);
+}
+
+proton_status_e SignalAccess::get_bytes(
+  uint32_t id, uint8_t * buf, size_t cap, size_t & len) const noexcept
+{
+  return proton_signal_get_bytes(registry_, id, buf, cap, &len);
+}
+proton_status_e SignalAccess::set_bytes(uint32_t id, const uint8_t * buf, size_t len) const noexcept
+{
+  return proton_signal_set_bytes(registry_, id, buf, len);
 }
 
 }  // namespace proton
-
-#endif  // PROTON_SIGNAL_HPP

--- a/cpp/src/signal_access.cpp
+++ b/cpp/src/signal_access.cpp
@@ -75,22 +75,21 @@ proton_status_e SignalAccess::set(uint32_t id, uint64_t value) noexcept
   return proton_signal_set_uint64(registry_, id, value);
 }
 
-proton_status_e SignalAccess::get_string(
-  uint32_t id, char * buf, size_t cap, size_t & len) const noexcept
+proton_status_e SignalAccess::get(uint32_t id, char * buf, size_t cap, size_t & len) const noexcept
 {
   return proton_signal_get_string(registry_, id, buf, cap, &len);
 }
-proton_status_e SignalAccess::set_string(uint32_t id, const char * buf, size_t len) const noexcept
+proton_status_e SignalAccess::set(uint32_t id, const char * buf, size_t len) const noexcept
 {
   return proton_signal_set_string(registry_, id, buf, len);
 }
 
-proton_status_e SignalAccess::get_bytes(
+proton_status_e SignalAccess::get(
   uint32_t id, uint8_t * buf, size_t cap, size_t & len) const noexcept
 {
   return proton_signal_get_bytes(registry_, id, buf, cap, &len);
 }
-proton_status_e SignalAccess::set_bytes(uint32_t id, const uint8_t * buf, size_t len) const noexcept
+proton_status_e SignalAccess::set(uint32_t id, const uint8_t * buf, size_t len) const noexcept
 {
   return proton_signal_set_bytes(registry_, id, buf, len);
 }

--- a/cpp/src/signal_access.cpp
+++ b/cpp/src/signal_access.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Rockwell Automation Technologies, Inc., All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Tom Wallis (thomas.wallis@rockwellautomation.com)
+ */
+
+#include "protoncpp/signal_access.hpp"
+
+namespace proton
+{
+
+proton_status_e SignalAccess::get(uint32_t id, double & out) const noexcept
+{
+  return proton_signal_get_double(registry_, id, &out);
+}
+proton_status_e SignalAccess::set(uint32_t id, double value) noexcept
+{
+  return proton_signal_set_double(registry, id, value);
+}
+
+proton_status_e SignalAccess::get(uint32_t id, float & out) const noexcept
+{
+  return proton_signal_get_float(registry_, id, &out);
+}
+proton_status_e SignalAccess::set(uint32_t id, float value) noexcept
+{
+  return proton_signal_set_float(registry, id, value);
+}
+
+proton_status_e SignalAccess::get(uint32_t id, int32_t & out) const noexcept
+{
+  return proton_signal_get_int32(registry_, id, &out);
+}
+proton_status_e SignalAccess::set(uint32_t id, int32_t value) noexcept
+{
+  return proton_signal_set_int32(registry, id, value);
+}
+
+proton_status_e SignalAccess::get(uint32_t id, int64_t & out) const noexcept
+{
+  return proton_signal_get_int64(registry_, id, &out);
+}
+proton_status_e SignalAccess::set(uint64_t id, int64_t value) noexcept
+{
+  return proton_signal_set_int64(registry, id, value);
+}
+
+proton_status_e SignalAccess::get(uint32_t id, uint32_t & out) const noexcept
+{
+  return proton_signal_get_uint32(registry_, id, &out);
+}
+proton_status_e SignalAccess::set(uint32_t id, uint32_t value) noexcept
+{
+  return proton_signal_set_uint32(registry, id, value);
+}
+
+proton_status_e SignalAccess::get(uint32_t id, uint64_t & out) const noexcept
+{
+  return proton_signal_get_uint64(registry_, id, &out);
+}
+proton_status_e SignalAccess::set(uint32_t id, uint64_t value) noexcept
+{
+  return proton_signal_set_uint64(registry, id, value);
+}
+
+proton_status_e SignalAccess::get_string(uint32_t id, char * buf, size_t cap, size_t & len)
+  const noexcept {return proton_signal_get_string(registry, id, buf, cap, &len)} proton_status_e
+  SignalAccess::set_string(uint32_t id, const char * buf, size_t len) const noexcept {
+    return proton_signal_set_string(registry, id, buf, len)}
+
+proton_status_e SignalAccess::get_bytes(uint32_t id, uint8_t * buf, size_t cap, size_t & len)
+  const noexcept {return proton_signal_get_bytes(registry, id, buf, cap, &len)} proton_status_e
+  SignalAccess::set_bytes(uint32_t id, const uint8_t * buf, size_t len) const noexcept
+{
+  return proton_signal_set_bytes(registry, id, buf, len)
+}
+
+}  // namespace proton
+
+#endif  // PROTON_SIGNAL_HPP

--- a/cpp/src/signal_access.cpp
+++ b/cpp/src/signal_access.cpp
@@ -52,7 +52,7 @@ proton_status_e SignalAccess::get(uint32_t id, int64_t & out) const noexcept
 {
   return proton_signal_get_int64(registry_, id, &out);
 }
-proton_status_e SignalAccess::set(uint64_t id, int64_t value) noexcept
+proton_status_e SignalAccess::set(uint32_t id, int64_t value) noexcept
 {
   return proton_signal_set_int64(registry_, id, value);
 }

--- a/cpp/tests/lock_test.cpp
+++ b/cpp/tests/lock_test.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Rockwell Automation Technologies, Inc., All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Tom Wallis (thomas.wallis@rockwellautomation.com)
+ */
+
+#include <gtest/gtest.h>
+#include "protoncpp/registry_lock.hpp"
+
+using namespace proton;
+
+TEST(RegistryLock, LockUnlock)
+{
+  proton_registry_t registry;
+  registry.mutex_handles.lock = [](void * mutex, void * ctx) -> proton_status_e
+  {
+    (void)ctx;
+    // Using mutex as a lock count for testing purposes
+    int * lock_count = static_cast<int *>(mutex);
+    *lock_count = 1;
+    return PROTON_OK;
+  };
+
+  registry.mutex_handles.unlock = [](void * mutex, void * ctx) -> proton_status_e
+  {
+    (void)mutex;
+    int * unlock_count = static_cast<int *>(ctx);
+    *unlock_count = 1;
+    return PROTON_OK;
+  };
+
+  int lock_count = 0;
+  int unlock_count = 0;
+  registry.mutex_handles.mutex = &lock_count;
+  registry.mutex_handles.arg = &unlock_count;
+
+  // Test that we can lock and unlock the registry without error
+  RegistryLock lock(&registry);
+  EXPECT_NO_THROW(lock.lock());
+  EXPECT_NO_THROW(lock.unlock());
+  EXPECT_EQ(lock_count, 1);
+  EXPECT_EQ(unlock_count, 1);
+}
+
+TEST(ScopedLock, LockUnlock)
+{
+  proton_registry_t registry;
+  registry.mutex_handles.lock = [](void * mutex, void * ctx) -> proton_status_e
+  {
+    (void)ctx;
+    int * lock_count = static_cast<int *>(mutex);
+    *lock_count = 1;
+    return PROTON_OK;
+  };
+
+  registry.mutex_handles.unlock = [](void * mutex, void * ctx) -> proton_status_e
+  {
+    (void)mutex;
+    int * unlock_count = static_cast<int *>(ctx);
+    *unlock_count = 1;
+    return PROTON_OK;
+  };
+
+  int lock_count = 0;
+  int unlock_count = 0;
+  registry.mutex_handles.mutex = &lock_count;
+  registry.mutex_handles.arg = &unlock_count;
+
+  // Test that the ScopedLock acquires and releases the lock properly
+  {
+    ScopedLock lock(&registry);
+    EXPECT_EQ(lock_count, 1);
+    EXPECT_EQ(unlock_count, 0);
+  }
+  EXPECT_EQ(unlock_count, 1);
+}
+
+TEST(ScopedLock, LockFailure)
+{
+  proton_registry_t registry;
+  registry.mutex_handles.lock = [](void * mutex, void * ctx) -> proton_status_e
+  {
+    (void)mutex;
+    (void)ctx;
+    return PROTON_ERROR;  // Simulate lock failure
+  };
+
+  registry.mutex_handles.unlock = [](void * mutex, void * ctx) -> proton_status_e
+  {
+    (void)mutex;
+    int * unlock_count = static_cast<int *>(ctx);
+    *unlock_count = 1;
+    return PROTON_OK;
+  };
+
+  int unlock_count = 0;
+  registry.mutex_handles.arg = &unlock_count;
+
+  // Test that the ScopedLock handles lock failure gracefully
+  {
+    ScopedLock lock(&registry);
+    EXPECT_FALSE(lock.ok());
+    EXPECT_EQ(unlock_count, 0);  // Unlock should not be called if lock failed
+  }
+  EXPECT_EQ(unlock_count, 0);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/cpp/tests/registry_test.cpp
+++ b/cpp/tests/registry_test.cpp
@@ -661,6 +661,141 @@ TEST(Signal, SetSignalTypeMismatch)
   free(registry.signal_registry);
 }
 
+// =============================================================================
+// BundleAccess tests
+// =============================================================================
+
+TEST(BundleAccess, Id)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  BundleAccess bundle(&registry, PROTON_BUNDLE_VALUE_TEST_ID);
+
+  EXPECT_EQ(bundle.id(), PROTON_BUNDLE_VALUE_TEST_ID);
+
+  free(registry.signal_registry);
+}
+
+TEST(BundleAccess, Descriptor)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  BundleAccess bundle(&registry, PROTON_BUNDLE_VALUE_TEST_ID);
+
+  const bundle_desc_t * desc = bundle.descriptor();
+  ASSERT_NE(desc, nullptr);
+  EXPECT_EQ(desc->bundle_id, PROTON_BUNDLE_VALUE_TEST_ID);
+  EXPECT_EQ(desc->producer_ids.count, 1);
+  EXPECT_EQ(desc->consumer_ids.count, 1);
+  EXPECT_EQ(desc->signal_ids.count, 9);
+
+  free(registry.signal_registry);
+}
+
+TEST(BundleAccess, DescriptorInvalidId)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  BundleAccess bundle(&registry, 0x9999);
+
+  const bundle_desc_t * desc = bundle.descriptor();
+  EXPECT_EQ(desc, nullptr);
+
+  free(registry.signal_registry);
+}
+
+TEST(BundleAccess, DescriptorBundleNotInTarget)
+{
+  // Bundle 0x1112 (unused_bundle) is defined in test.yaml but the producer
+  // is not "producer", so it won't be in the target's registry
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  BundleAccess bundle(&registry, 0x1112);
+
+  const bundle_desc_t * desc = bundle.descriptor();
+  EXPECT_EQ(desc, nullptr);
+
+  free(registry.signal_registry);
+}
+
+TEST(BundleAccess, CheckBundlePeriodPopulated)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  BundleAccess bundle(&registry, PROTON_BUNDLE_PERIODIC_BUNDLE_ID);
+
+  const bundle_desc_t * desc = bundle.descriptor();
+  ASSERT_NE(desc, nullptr);
+  EXPECT_EQ(desc->period_ms, 100);
+
+  free(registry.signal_registry);
+}
+
+TEST(BundleAccess, SetPeriod)
+{
+  const uint32_t new_period = 200;
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  BundleAccess bundle(&registry, PROTON_BUNDLE_PERIODIC_BUNDLE_ID);
+
+  bundle.set_period(new_period);
+
+  const bundle_desc_t * desc = bundle.descriptor();
+  ASSERT_NE(desc, nullptr);
+  EXPECT_EQ(desc->period_ms, new_period);
+
+  free(registry.signal_registry);
+}
+
+typedef struct callback_context
+{
+  bool called;
+  uint32_t bundle_id;
+  size_t signal_count;
+} callback_context_t;
+
+static void test_bundle_callback(
+  uint32_t bundle_id, const uint32_t * signal_ids, size_t count, void * ctx)
+{
+  (void)signal_ids;
+  callback_context_t * context = static_cast<callback_context_t *>(ctx);
+  if (context)
+  {
+    context->called = true;
+    context->bundle_id = bundle_id;
+    context->signal_count = count;
+  }
+}
+
+TEST(BundleAccess, SetCallback)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  BundleAccess bundle(&registry, PROTON_BUNDLE_VALUE_TEST_ID);
+
+  callback_context_t ctx;
+  bundle.set_callback(test_bundle_callback, &ctx);
+
+  // Verify callback was registered by retrieving it
+  proton_bundle_cb_t * cb =
+    proton_registry_get_bundle_callback(&registry, PROTON_BUNDLE_VALUE_TEST_ID);
+  ASSERT_NE(cb, nullptr);
+  EXPECT_EQ(cb->cb, test_bundle_callback);
+  EXPECT_EQ(cb->arg, &ctx);
+
+  free(registry.signal_registry);
+}
+
+TEST(BundleAccess, SetCallbackNullptr)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  BundleAccess bundle(&registry, PROTON_BUNDLE_VALUE_TEST_ID);
+
+  // Setting nullptr callback should be allowed (to clear callback)
+  bundle.set_callback(nullptr, nullptr);
+
+  proton_bundle_cb_t * cb =
+    proton_registry_get_bundle_callback(&registry, PROTON_BUNDLE_VALUE_TEST_ID);
+  ASSERT_NE(cb, nullptr);
+  EXPECT_EQ(cb->cb, nullptr);
+  EXPECT_EQ(cb->arg, nullptr);
+
+  free(registry.signal_registry);
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/cpp/tests/registry_test.cpp
+++ b/cpp/tests/registry_test.cpp
@@ -24,6 +24,10 @@
 #include "target_registry_sizes.h"
 #include "utils.hpp"
 
+#if PROTON_ENABLE_ALLOC
+#include <vector>
+#endif
+
 extern proton_registry_t g_proton_registry;
 
 using namespace proton;
@@ -956,6 +960,145 @@ TEST(BundleAccess, SetCallbackNullptr)
 
   free(registry.signal_registry);
 }
+
+// =============================================================================
+// BundleAccess std::function callback tests (PROTON_ENABLE_ALLOC only)
+// =============================================================================
+
+#if PROTON_ENABLE_ALLOC
+
+TEST(BundleAccess, SetStdFunctionCallback)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  BundleAccess bundle(&registry, PROTON_BUNDLE_VALUE_TEST_ID);
+
+  bool callback_called = false;
+  uint32_t received_bundle_id = 0;
+  size_t received_signal_count = 0;
+
+  bundle.set_callback(
+    [&](uint32_t bundle_id, const uint32_t * signal_ids, size_t count)
+    {
+      (void)signal_ids;
+      callback_called = true;
+      received_bundle_id = bundle_id;
+      received_signal_count = count;
+    });
+
+  // Verify callback was registered
+  proton_bundle_cb_t * cb =
+    proton_registry_get_bundle_callback(&registry, PROTON_BUNDLE_VALUE_TEST_ID);
+  ASSERT_NE(cb, nullptr);
+  ASSERT_NE(cb->cb, nullptr);
+
+  // Simulate callback invocation
+  const bundle_desc_t * desc = bundle.descriptor();
+  ASSERT_NE(desc, nullptr);
+  cb->cb(PROTON_BUNDLE_VALUE_TEST_ID, desc->signal_ids.ids, desc->signal_ids.count, cb->arg);
+
+  EXPECT_TRUE(callback_called);
+  EXPECT_EQ(received_bundle_id, PROTON_BUNDLE_VALUE_TEST_ID);
+  EXPECT_EQ(received_signal_count, desc->signal_ids.count);
+
+  free(registry.signal_registry);
+}
+
+TEST(BundleAccess, SetStdFunctionCallbackWithCapture)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  BundleAccess bundle(&registry, PROTON_BUNDLE_VALUE_TEST_ID);
+
+  int counter = 0;
+  std::vector<uint32_t> captured_signal_ids;
+
+  bundle.set_callback(
+    [&counter, &captured_signal_ids](uint32_t bundle_id, const uint32_t * signal_ids, size_t count)
+    {
+      (void)bundle_id;
+      counter++;
+      captured_signal_ids.assign(signal_ids, signal_ids + count);
+    });
+
+  // Get callback and invoke multiple times
+  proton_bundle_cb_t * cb =
+    proton_registry_get_bundle_callback(&registry, PROTON_BUNDLE_VALUE_TEST_ID);
+  ASSERT_NE(cb, nullptr);
+
+  const bundle_desc_t * desc = bundle.descriptor();
+  ASSERT_NE(desc, nullptr);
+
+  cb->cb(PROTON_BUNDLE_VALUE_TEST_ID, desc->signal_ids.ids, desc->signal_ids.count, cb->arg);
+  cb->cb(PROTON_BUNDLE_VALUE_TEST_ID, desc->signal_ids.ids, desc->signal_ids.count, cb->arg);
+  cb->cb(PROTON_BUNDLE_VALUE_TEST_ID, desc->signal_ids.ids, desc->signal_ids.count, cb->arg);
+
+  EXPECT_EQ(counter, 3);
+  EXPECT_EQ(captured_signal_ids.size(), desc->signal_ids.count);
+
+  free(registry.signal_registry);
+}
+
+TEST(BundleAccess, ReplaceStdFunctionCallback)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  BundleAccess bundle(&registry, PROTON_BUNDLE_VALUE_TEST_ID);
+
+  int first_counter = 0;
+  int second_counter = 0;
+
+  // Set first callback
+  bundle.set_callback([&first_counter](uint32_t, const uint32_t *, size_t) { first_counter++; });
+
+  proton_bundle_cb_t * cb =
+    proton_registry_get_bundle_callback(&registry, PROTON_BUNDLE_VALUE_TEST_ID);
+  const bundle_desc_t * desc = bundle.descriptor();
+  cb->cb(PROTON_BUNDLE_VALUE_TEST_ID, desc->signal_ids.ids, desc->signal_ids.count, cb->arg);
+
+  EXPECT_EQ(first_counter, 1);
+  EXPECT_EQ(second_counter, 0);
+
+  // Replace with second callback
+  bundle.set_callback([&second_counter](uint32_t, const uint32_t *, size_t) { second_counter++; });
+
+  cb = proton_registry_get_bundle_callback(&registry, PROTON_BUNDLE_VALUE_TEST_ID);
+  cb->cb(PROTON_BUNDLE_VALUE_TEST_ID, desc->signal_ids.ids, desc->signal_ids.count, cb->arg);
+
+  // First callback should not be called again, second should be called
+  EXPECT_EQ(first_counter, 1);
+  EXPECT_EQ(second_counter, 1);
+
+  free(registry.signal_registry);
+}
+
+TEST(BundleAccess, StdFunctionCallbackReceivesCorrectSignalIds)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  BundleAccess bundle(&registry, PROTON_BUNDLE_VALUE_TEST_ID);
+
+  std::vector<uint32_t> received_ids;
+
+  bundle.set_callback([&received_ids](uint32_t, const uint32_t * signal_ids, size_t count)
+                      { received_ids.assign(signal_ids, signal_ids + count); });
+
+  const bundle_desc_t * desc = bundle.descriptor();
+  ASSERT_NE(desc, nullptr);
+
+  proton_bundle_cb_t * cb =
+    proton_registry_get_bundle_callback(&registry, PROTON_BUNDLE_VALUE_TEST_ID);
+  cb->cb(PROTON_BUNDLE_VALUE_TEST_ID, desc->signal_ids.ids, desc->signal_ids.count, cb->arg);
+
+  // value_test bundle has 9 signals (see test.yaml)
+  ASSERT_EQ(received_ids.size(), 9);
+
+  // Verify the signal IDs match those in the bundle descriptor
+  for (size_t i = 0; i < desc->signal_ids.count; i++)
+  {
+    EXPECT_EQ(received_ids[i], desc->signal_ids.ids[i]);
+  }
+
+  free(registry.signal_registry);
+}
+
+#endif  // PROTON_ENABLE_ALLOC
 
 int main(int argc, char ** argv)
 {

--- a/cpp/tests/registry_test.cpp
+++ b/cpp/tests/registry_test.cpp
@@ -251,6 +251,416 @@ TEST(SignalAccess, GetInvalidSignalId)
   free(registry.signal_registry);
 }
 
+TEST(SignalAccess, SetInvalidSignalId)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  double new_value = 1.23;
+  proton_status_e status = access.set(0x9999, new_value);
+  EXPECT_EQ(status, PROTON_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, GetSignalIdNotInTarget)
+{
+  // Signal ID 0x1111 is defined in test.yaml, but it is not part of any bundle that
+  // the test producer is part of.
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  float value;
+  proton_status_e status = access.get(0x1111, value);
+  EXPECT_EQ(status, PROTON_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, GetSignalTypeMismatch)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  // The double-typed signal cannot be read as a uint32
+  uint32_t value;
+  proton_status_e status = access.get(PROTON_SIGNAL_DEFAULT_DOUBLE_ID, value);
+  EXPECT_EQ(status, PROTON_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, SetSignalTypeMismatch)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  // The double-typed signal cannot be written as a uint32
+  uint32_t value = 42;
+  proton_status_e status = access.set(PROTON_SIGNAL_DEFAULT_DOUBLE_ID, value);
+  EXPECT_EQ(status, PROTON_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, SetStringNullPtr)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  // String setter with null data should be rejected
+  proton_status_e status = access.set(PROTON_SIGNAL_STRING_VALUE_ID, (const char *)nullptr, 4);
+  EXPECT_EQ(status, PROTON_NULL_PTR_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, SetBytesNullPtr)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  // Bytes setter with null data should be rejected
+  proton_status_e status = access.set(PROTON_SIGNAL_BYTES_VALUE_ID, (const uint8_t *)nullptr, 4);
+  EXPECT_EQ(status, PROTON_NULL_PTR_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, SetStringExcessiveLength)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  char new_value[PROTON_SIGNAL_STRING_VALUE_CAPACITY + 1] = {0};
+  memset(new_value, 'a', PROTON_SIGNAL_STRING_VALUE_CAPACITY);
+  proton_status_e status = access.set(PROTON_SIGNAL_STRING_VALUE_ID, new_value, 999);
+  EXPECT_EQ(status, PROTON_INSUFFICIENT_BUFFER_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, SetBytesExcessiveLength)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  uint8_t new_value[PROTON_SIGNAL_BYTES_VALUE_CAPACITY + 1] = {0};
+  memset(new_value, 0xFF, PROTON_SIGNAL_BYTES_VALUE_CAPACITY);
+  proton_status_e status = access.set(PROTON_SIGNAL_BYTES_VALUE_ID, new_value, 999);
+  EXPECT_EQ(status, PROTON_INSUFFICIENT_BUFFER_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, SetStringNotNullTerminated)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  char new_value[PROTON_SIGNAL_STRING_VALUE_CAPACITY] = {0};
+  memset(new_value, 'a', PROTON_SIGNAL_STRING_VALUE_CAPACITY);  // No null terminator
+  proton_status_e status = access.set(PROTON_SIGNAL_STRING_VALUE_ID, new_value, sizeof(new_value));
+  EXPECT_EQ(status, PROTON_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, SetStringNullTerminatorAtCapacity)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  char new_value[PROTON_SIGNAL_STRING_VALUE_CAPACITY] = {0};
+  memset(new_value, 'a', PROTON_SIGNAL_STRING_VALUE_CAPACITY - 1);
+  new_value[PROTON_SIGNAL_STRING_VALUE_CAPACITY - 1] = '\0';  // Null terminator at capacity
+  proton_status_e status = access.set(PROTON_SIGNAL_STRING_VALUE_ID, new_value, sizeof(new_value));
+  EXPECT_EQ(status, PROTON_OK);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, SetGetLongString)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  const char * new_value = "ipsumsedolorsitametconsecteturadipiscingeaaa";
+  size_t new_len = strlen(new_value) + 1;
+  proton_status_e status = access.set(PROTON_SIGNAL_REALLY_LONG_STRING_ID, new_value, new_len);
+  ASSERT_EQ(status, PROTON_OK);
+
+  // Read the value back to verify it was set
+  char buf[PROTON_SIGNAL_REALLY_LONG_STRING_CAPACITY] = {0};
+  size_t len = 0;
+  status = access.get(PROTON_SIGNAL_REALLY_LONG_STRING_ID, buf, sizeof(buf), len);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(len, new_len);
+  EXPECT_STREQ(buf, new_value);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, SetGetLongBytes)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  uint8_t new_value[PROTON_SIGNAL_REALLY_LONG_BYTES_CAPACITY] = {0};
+  memset(new_value, 0xAB, PROTON_SIGNAL_REALLY_LONG_BYTES_CAPACITY);
+  proton_status_e status =
+    access.set(PROTON_SIGNAL_REALLY_LONG_BYTES_ID, new_value, sizeof(new_value));
+  ASSERT_EQ(status, PROTON_OK);
+
+  // Read the value back to verify it was set
+  uint8_t buf[PROTON_SIGNAL_REALLY_LONG_BYTES_CAPACITY] = {0};
+  size_t len = 0;
+  status = access.get(PROTON_SIGNAL_REALLY_LONG_BYTES_ID, buf, sizeof(buf), len);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(len, sizeof(new_value));
+  EXPECT_EQ(memcmp(buf, new_value, len), 0);
+
+  free(registry.signal_registry);
+}
+
+// =============================================================================
+// Signal<T> template class tests
+// =============================================================================
+
+TEST(Signal, GetDouble)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<double> signal(&registry, PROTON_SIGNAL_DEFAULT_DOUBLE_ID);
+
+  double value;
+  proton_status_e status = signal.get(value);
+  EXPECT_EQ(status, PROTON_OK);
+  EXPECT_EQ(value, 3.14159);
+
+  free(registry.signal_registry);
+}
+
+TEST(Signal, SetDouble)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<double> signal(&registry, PROTON_SIGNAL_DOUBLE_VALUE_ID);
+
+  double new_value = 2.71828;
+  proton_status_e status = signal.set(new_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  double value;
+  status = signal.get(value);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(value, new_value);
+
+  free(registry.signal_registry);
+}
+
+TEST(Signal, GetSetFloat)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<float> signal(&registry, PROTON_SIGNAL_FLOAT_VALUE_ID);
+
+  float new_value = 1.5f;
+  proton_status_e status = signal.set(new_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  float value;
+  status = signal.get(value);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_FLOAT_EQ(value, new_value);
+
+  free(registry.signal_registry);
+}
+
+TEST(Signal, GetSetInt32)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<int32_t> signal(&registry, PROTON_SIGNAL_INT32_VALUE_ID);
+
+  int32_t new_value = -42;
+  proton_status_e status = signal.set(new_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  int32_t value;
+  status = signal.get(value);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(value, new_value);
+
+  free(registry.signal_registry);
+}
+
+TEST(Signal, GetSetInt64)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<int64_t> signal(&registry, PROTON_SIGNAL_INT64_VALUE_ID);
+
+  int64_t new_value = -9223372036854775807LL;
+  proton_status_e status = signal.set(new_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  int64_t value;
+  status = signal.get(value);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(value, new_value);
+
+  free(registry.signal_registry);
+}
+
+TEST(Signal, GetSetUint32)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<uint32_t> signal(&registry, PROTON_SIGNAL_UINT32_VALUE_ID);
+
+  uint32_t new_value = 0xDEADBEEF;
+  proton_status_e status = signal.set(new_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  uint32_t value;
+  status = signal.get(value);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(value, new_value);
+
+  free(registry.signal_registry);
+}
+
+TEST(Signal, GetSetUint64)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<uint64_t> signal(&registry, PROTON_SIGNAL_UINT64_VALUE_ID);
+
+  uint64_t new_value = 0xDEADBEEFCAFEBABEULL;
+  proton_status_e status = signal.set(new_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  uint64_t value;
+  status = signal.get(value);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(value, new_value);
+
+  free(registry.signal_registry);
+}
+
+TEST(Signal, GetSetBool)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<bool> signal(&registry, PROTON_SIGNAL_BOOL_VALUE_ID);
+
+  proton_status_e status = signal.set(true);
+  ASSERT_EQ(status, PROTON_OK);
+
+  bool value;
+  status = signal.get(value);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_TRUE(value);
+
+  // Test false as well
+  status = signal.set(false);
+  ASSERT_EQ(status, PROTON_OK);
+  status = signal.get(value);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_FALSE(value);
+
+  free(registry.signal_registry);
+}
+
+TEST(Signal, Id)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<double> signal(&registry, PROTON_SIGNAL_DOUBLE_VALUE_ID);
+
+  EXPECT_EQ(signal.id(), PROTON_SIGNAL_DOUBLE_VALUE_ID);
+
+  free(registry.signal_registry);
+}
+
+TEST(Signal, Desc)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<double> signal(&registry, PROTON_SIGNAL_DEFAULT_DOUBLE_ID);
+
+  signal_desc_t * desc = signal.desc();
+  ASSERT_NE(desc, nullptr);
+  EXPECT_EQ(desc->id, PROTON_SIGNAL_DEFAULT_DOUBLE_ID);
+  EXPECT_EQ(desc->type, PROTON_DOUBLE);
+
+  free(registry.signal_registry);
+}
+
+TEST(Signal, DescInvalidId)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<double> signal(&registry, 0x9999);
+
+  signal_desc_t * desc = signal.desc();
+  EXPECT_EQ(desc, nullptr);
+
+  free(registry.signal_registry);
+}
+
+TEST(Signal, GetInvalidSignalId)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<double> signal(&registry, 0x9999);
+
+  double value;
+  proton_status_e status = signal.get(value);
+  EXPECT_EQ(status, PROTON_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(Signal, SetInvalidSignalId)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<double> signal(&registry, 0x9999);
+
+  proton_status_e status = signal.set(1.23);
+  EXPECT_EQ(status, PROTON_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(Signal, GetSignalIdNotInTarget)
+{
+  // Signal ID 0x1111 is defined in test.yaml, but it is not part of any bundle that
+  // the test producer is part of.
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<float> signal(&registry, 0x1111);
+
+  float value;
+  proton_status_e status = signal.get(value);
+  EXPECT_EQ(status, PROTON_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(Signal, GetSignalTypeMismatch)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  // Create Signal<uint32_t> for a double signal - type mismatch
+  Signal<uint32_t> signal(&registry, PROTON_SIGNAL_DEFAULT_DOUBLE_ID);
+
+  uint32_t value;
+  proton_status_e status = signal.get(value);
+  EXPECT_EQ(status, PROTON_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(Signal, SetSignalTypeMismatch)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  // Create Signal<uint32_t> for a double signal - type mismatch
+  Signal<uint32_t> signal(&registry, PROTON_SIGNAL_DEFAULT_DOUBLE_ID);
+
+  proton_status_e status = signal.set(42);
+  EXPECT_EQ(status, PROTON_ERROR);
+
+  free(registry.signal_registry);
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/cpp/tests/registry_test.cpp
+++ b/cpp/tests/registry_test.cpp
@@ -666,6 +666,251 @@ TEST(Signal, SetSignalTypeMismatch)
 }
 
 // =============================================================================
+// Signal<char*> tests
+// =============================================================================
+
+TEST(SignalString, GetDefaultString)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<char *> signal(&registry, PROTON_SIGNAL_DEFAULT_STRING_ID);
+
+  char buf[PROTON_SIGNAL_DEFAULT_STRING_CAPACITY] = {0};
+  size_t len = 0;
+  proton_status_e status = signal.get(buf, sizeof(buf), len);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_STREQ(buf, "foo");
+  EXPECT_EQ(len, strlen(buf) + 1);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalString, SetString)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<char *> signal(&registry, PROTON_SIGNAL_STRING_VALUE_ID);
+
+  const char * new_value = "bar";
+  proton_status_e status = signal.set(new_value, strlen(new_value) + 1);
+  ASSERT_EQ(status, PROTON_OK);
+
+  char buf[PROTON_SIGNAL_STRING_VALUE_CAPACITY] = {0};
+  size_t len = 0;
+  status = signal.get(buf, sizeof(buf), len);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_STREQ(buf, new_value);
+  EXPECT_EQ(len, strlen(new_value) + 1);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalString, SetStringNullPtr)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<char *> signal(&registry, PROTON_SIGNAL_STRING_VALUE_ID);
+
+  char * buf = nullptr;
+
+  proton_status_e status = signal.set(buf, 4);
+  EXPECT_EQ(status, PROTON_NULL_PTR_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalString, SetStringExcessiveLength)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<char *> signal(&registry, PROTON_SIGNAL_STRING_VALUE_ID);
+
+  char new_value[PROTON_SIGNAL_STRING_VALUE_CAPACITY + 1] = {0};
+  memset(new_value, 'a', PROTON_SIGNAL_STRING_VALUE_CAPACITY);
+  proton_status_e status = signal.set(new_value, 999);
+  EXPECT_EQ(status, PROTON_INSUFFICIENT_BUFFER_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalString, SetStringNotNullTerminated)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<char *> signal(&registry, PROTON_SIGNAL_STRING_VALUE_ID);
+
+  char new_value[PROTON_SIGNAL_STRING_VALUE_CAPACITY] = {0};
+  memset(new_value, 'a', PROTON_SIGNAL_STRING_VALUE_CAPACITY);  // No null terminator
+  proton_status_e status = signal.set(new_value, sizeof(new_value));
+  EXPECT_EQ(status, PROTON_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalString, SetStringNullTerminatorAtCapacity)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<char *> signal(&registry, PROTON_SIGNAL_STRING_VALUE_ID);
+
+  char new_value[PROTON_SIGNAL_STRING_VALUE_CAPACITY] = {0};
+  memset(new_value, 'a', PROTON_SIGNAL_STRING_VALUE_CAPACITY - 1);
+  new_value[PROTON_SIGNAL_STRING_VALUE_CAPACITY - 1] = '\0';  // Null terminator at capacity
+  proton_status_e status = signal.set(new_value, sizeof(new_value));
+  EXPECT_EQ(status, PROTON_OK);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalString, SetGetLongString)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<char *> signal(&registry, PROTON_SIGNAL_REALLY_LONG_STRING_ID);
+
+  const char * new_value = "ipsumsedolorsitametconsecteturadipiscingeaaa";
+  size_t new_len = strlen(new_value) + 1;
+  proton_status_e status = signal.set(new_value, new_len);
+  ASSERT_EQ(status, PROTON_OK);
+
+  char buf[PROTON_SIGNAL_REALLY_LONG_STRING_CAPACITY] = {0};
+  size_t len = 0;
+  status = signal.get(buf, sizeof(buf), len);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(len, new_len);
+  EXPECT_STREQ(buf, new_value);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalString, GetInvalidSignalId)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<char *> signal(&registry, 0x9999);
+
+  char buf[64] = {0};
+  size_t len = 0;
+  proton_status_e status = signal.get(buf, sizeof(buf), len);
+  EXPECT_EQ(status, PROTON_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalString, SetInvalidSignalId)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<char *> signal(&registry, 0x9999);
+
+  proton_status_e status = signal.set("test", 5);
+  EXPECT_EQ(status, PROTON_ERROR);
+
+  free(registry.signal_registry);
+}
+
+// =============================================================================
+// Signal<uint8_t*> tests
+// =============================================================================
+
+TEST(SignalBytes, GetDefaultBytes)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<uint8_t *> signal(&registry, PROTON_SIGNAL_DEFAULT_BYTES_ID);
+
+  uint8_t buf[PROTON_SIGNAL_DEFAULT_BYTES_CAPACITY] = {0};
+  size_t len = 0;
+  proton_status_e status = signal.get(buf, sizeof(buf), len);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(len, 3);
+  EXPECT_EQ(buf[0], 0);
+  EXPECT_EQ(buf[1], 1);
+  EXPECT_EQ(buf[2], 2);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalBytes, SetBytes)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<uint8_t *> signal(&registry, PROTON_SIGNAL_BYTES_VALUE_ID);
+
+  uint8_t new_value[] = {0xAA, 0xBB, 0xCC, 0xDD};
+  proton_status_e status = signal.set(new_value, sizeof(new_value));
+  ASSERT_EQ(status, PROTON_OK);
+
+  uint8_t buf[PROTON_SIGNAL_BYTES_VALUE_CAPACITY] = {0};
+  size_t len = 0;
+  status = signal.get(buf, sizeof(buf), len);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(len, sizeof(new_value));
+  EXPECT_EQ(memcmp(buf, new_value, len), 0);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalBytes, SetBytesNullPtr)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<uint8_t *> signal(&registry, PROTON_SIGNAL_BYTES_VALUE_ID);
+
+  uint8_t * buf = nullptr;
+  proton_status_e status = signal.set(buf, 4);
+  EXPECT_EQ(status, PROTON_NULL_PTR_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalBytes, SetBytesExcessiveLength)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<uint8_t *> signal(&registry, PROTON_SIGNAL_BYTES_VALUE_ID);
+
+  uint8_t new_value[PROTON_SIGNAL_BYTES_VALUE_CAPACITY + 1] = {0};
+  memset(new_value, 0xFF, PROTON_SIGNAL_BYTES_VALUE_CAPACITY);
+  proton_status_e status = signal.set(new_value, 999);
+  EXPECT_EQ(status, PROTON_INSUFFICIENT_BUFFER_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalBytes, SetGetLongBytes)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<uint8_t *> signal(&registry, PROTON_SIGNAL_REALLY_LONG_BYTES_ID);
+
+  uint8_t new_value[PROTON_SIGNAL_REALLY_LONG_BYTES_CAPACITY] = {0};
+  memset(new_value, 0xAB, PROTON_SIGNAL_REALLY_LONG_BYTES_CAPACITY);
+  proton_status_e status = signal.set(new_value, sizeof(new_value));
+  ASSERT_EQ(status, PROTON_OK);
+
+  uint8_t buf[PROTON_SIGNAL_REALLY_LONG_BYTES_CAPACITY] = {0};
+  size_t len = 0;
+  status = signal.get(buf, sizeof(buf), len);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(len, sizeof(new_value));
+  EXPECT_EQ(memcmp(buf, new_value, len), 0);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalBytes, GetInvalidSignalId)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<uint8_t *> signal(&registry, 0x9999);
+
+  uint8_t buf[64] = {0};
+  size_t len = 0;
+  proton_status_e status = signal.get(buf, sizeof(buf), len);
+  EXPECT_EQ(status, PROTON_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalBytes, SetInvalidSignalId)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<uint8_t *> signal(&registry, 0x9999);
+
+  uint8_t data[] = {0x01, 0x02};
+  proton_status_e status = signal.set(data, sizeof(data));
+  EXPECT_EQ(status, PROTON_ERROR);
+
+  free(registry.signal_registry);
+}
+
+// =============================================================================
 // SignalBase tests (no-RTTI type checking)
 // =============================================================================
 

--- a/cpp/tests/registry_test.cpp
+++ b/cpp/tests/registry_test.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Rockwell Automation Technologies, Inc., All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Tom Wallis (thomas.wallis@rockwellautomation.com)
+ */
+
+#include <gtest/gtest.h>
+#include "protoncpp/bundle_access.hpp"
+#include "protoncpp/signal_access.hpp"
+#include "target_registry_ids.h"
+#include "target_registry_sizes.h"
+#include "utils.hpp"
+
+extern proton_registry_t g_proton_registry;
+
+TEST(SignalAccess, GetDouble) {}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/cpp/tests/registry_test.cpp
+++ b/cpp/tests/registry_test.cpp
@@ -662,6 +662,167 @@ TEST(Signal, SetSignalTypeMismatch)
 }
 
 // =============================================================================
+// SignalBase tests (no-RTTI type checking)
+// =============================================================================
+
+TEST(SignalBase, TypeDouble)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<double> signal(&registry, PROTON_SIGNAL_DEFAULT_DOUBLE_ID);
+  SignalBase * base = &signal;
+
+  EXPECT_EQ(base->type(), PROTON_DOUBLE);
+  EXPECT_EQ(base->id(), PROTON_SIGNAL_DEFAULT_DOUBLE_ID);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalBase, TypeFloat)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<float> signal(&registry, PROTON_SIGNAL_FLOAT_VALUE_ID);
+  SignalBase * base = &signal;
+
+  EXPECT_EQ(base->type(), PROTON_FLOAT);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalBase, TypeInt32)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<int32_t> signal(&registry, PROTON_SIGNAL_INT32_VALUE_ID);
+  SignalBase * base = &signal;
+
+  EXPECT_EQ(base->type(), PROTON_INT32);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalBase, TypeInt64)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<int64_t> signal(&registry, PROTON_SIGNAL_INT64_VALUE_ID);
+  SignalBase * base = &signal;
+
+  EXPECT_EQ(base->type(), PROTON_INT64);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalBase, TypeUint32)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<uint32_t> signal(&registry, PROTON_SIGNAL_UINT32_VALUE_ID);
+  SignalBase * base = &signal;
+
+  EXPECT_EQ(base->type(), PROTON_UINT32);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalBase, TypeUint64)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<uint64_t> signal(&registry, PROTON_SIGNAL_UINT64_VALUE_ID);
+  SignalBase * base = &signal;
+
+  EXPECT_EQ(base->type(), PROTON_UINT64);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalBase, TypeBool)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<bool> signal(&registry, PROTON_SIGNAL_BOOL_VALUE_ID);
+  SignalBase * base = &signal;
+
+  EXPECT_EQ(base->type(), PROTON_BOOL);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalBase, TypeString)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<double> signal(&registry, PROTON_SIGNAL_STRING_VALUE_ID);
+  SignalBase * base = &signal;
+
+  EXPECT_EQ(base->type(), PROTON_STRING);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalBase, TypeBytes)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<double> signal(&registry, PROTON_SIGNAL_BYTES_VALUE_ID);
+  SignalBase * base = &signal;
+
+  EXPECT_EQ(base->type(), PROTON_BYTES);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalBase, TypeInvalidId)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<double> signal(&registry, 0x9999);
+  SignalBase * base = &signal;
+
+  EXPECT_EQ(base->type(), PROTON_INVALID_TYPE);
+  EXPECT_EQ(base->desc(), nullptr);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalBase, DescReturnsValidDescriptor)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<double> signal(&registry, PROTON_SIGNAL_DEFAULT_DOUBLE_ID);
+  SignalBase * base = &signal;
+
+  signal_desc_t * desc = base->desc();
+  ASSERT_NE(desc, nullptr);
+  EXPECT_EQ(desc->id, PROTON_SIGNAL_DEFAULT_DOUBLE_ID);
+  EXPECT_EQ(desc->type, PROTON_DOUBLE);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalBase, PolymorphicAccessViaBasePointer)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+
+  Signal<double> double_signal(&registry, PROTON_SIGNAL_DOUBLE_VALUE_ID);
+  Signal<uint32_t> uint32_signal(&registry, PROTON_SIGNAL_UINT32_VALUE_ID);
+  Signal<bool> bool_signal(&registry, PROTON_SIGNAL_BOOL_VALUE_ID);
+
+  // Store in array of base pointers
+  SignalBase * signals[] = {&double_signal, &uint32_signal, &bool_signal};
+
+  // Verify type checking works for each
+  EXPECT_EQ(signals[0]->type(), PROTON_DOUBLE);
+  EXPECT_EQ(signals[1]->type(), PROTON_UINT32);
+  EXPECT_EQ(signals[2]->type(), PROTON_BOOL);
+
+  // Verify safe casting pattern (no RTTI)
+  if (signals[0]->type() == PROTON_DOUBLE)
+  {
+    auto * typed = static_cast<Signal<double> *>(signals[0]);
+    double value = 123.456;
+    EXPECT_EQ(typed->set(value), PROTON_OK);
+
+    double read_value;
+    EXPECT_EQ(typed->get(read_value), PROTON_OK);
+    EXPECT_EQ(read_value, value);
+  }
+
+  free(registry.signal_registry);
+}
+
+// =============================================================================
 // BundleAccess tests
 // =============================================================================
 

--- a/cpp/tests/registry_test.cpp
+++ b/cpp/tests/registry_test.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <cstring>
 #include "protoncpp/bundle_access.hpp"
 #include "protoncpp/signal_access.hpp"
 #include "target_registry_ids.h"
@@ -25,7 +26,230 @@
 
 extern proton_registry_t g_proton_registry;
 
-TEST(SignalAccess, GetDouble) {}
+using namespace proton;
+
+TEST(SignalAccess, GetDouble)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+
+  double value;
+  SignalAccess access(&registry);
+  proton_status_e status = access.get(PROTON_SIGNAL_DEFAULT_DOUBLE_ID, value);
+  EXPECT_EQ(status, PROTON_OK);
+  EXPECT_EQ(value, 3.14159);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, SetDouble)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+
+  double new_value = 2.71828;
+  SignalAccess access(&registry);
+  proton_status_e status = access.set(PROTON_SIGNAL_DOUBLE_VALUE_ID, new_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  // Read the value back to verify it was set
+  double value;
+  status = access.get(PROTON_SIGNAL_DOUBLE_VALUE_ID, value);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(value, new_value);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, GetSetFloat)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  float new_value = 1.5f;
+  proton_status_e status = access.set(PROTON_SIGNAL_FLOAT_VALUE_ID, new_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  float value;
+  status = access.get(PROTON_SIGNAL_FLOAT_VALUE_ID, value);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_FLOAT_EQ(value, new_value);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, GetSetInt32)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  int32_t new_value = -42;
+  proton_status_e status = access.set(PROTON_SIGNAL_INT32_VALUE_ID, new_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  int32_t value;
+  status = access.get(PROTON_SIGNAL_INT32_VALUE_ID, value);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(value, new_value);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, GetSetInt64)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  int64_t new_value = -9223372036854775807LL;
+  proton_status_e status = access.set(PROTON_SIGNAL_INT64_VALUE_ID, new_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  int64_t value;
+  status = access.get(PROTON_SIGNAL_INT64_VALUE_ID, value);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(value, new_value);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, GetSetUint32)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  uint32_t new_value = 0xDEADBEEF;
+  proton_status_e status = access.set(PROTON_SIGNAL_UINT32_VALUE_ID, new_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  uint32_t value;
+  status = access.get(PROTON_SIGNAL_UINT32_VALUE_ID, value);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(value, new_value);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, GetSetUint64)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  uint64_t new_value = 0xDEADBEEFCAFEBABEULL;
+  proton_status_e status = access.set(PROTON_SIGNAL_UINT64_VALUE_ID, new_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  uint64_t value;
+  status = access.get(PROTON_SIGNAL_UINT64_VALUE_ID, value);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(value, new_value);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, GetSetBool)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  bool new_value = true;
+  proton_status_e status = access.set(PROTON_SIGNAL_BOOL_VALUE_ID, new_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  bool value;
+  status = access.get(PROTON_SIGNAL_BOOL_VALUE_ID, value);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(value, new_value);
+
+  // Test false as well
+  status = access.set(PROTON_SIGNAL_BOOL_VALUE_ID, false);
+  ASSERT_EQ(status, PROTON_OK);
+  status = access.get(PROTON_SIGNAL_BOOL_VALUE_ID, value);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_FALSE(value);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, GetDefaultString)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  char buf[PROTON_SIGNAL_DEFAULT_STRING_CAPACITY] = {0};
+  size_t len = 0;
+  proton_status_e status = access.get(PROTON_SIGNAL_DEFAULT_STRING_ID, buf, sizeof(buf), len);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_STREQ(buf, "foo");
+  EXPECT_EQ(len, strlen(buf) + 1);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, SetString)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  const char * new_value = "bar";
+  proton_status_e status =
+    access.set(PROTON_SIGNAL_STRING_VALUE_ID, new_value, strlen(new_value) + 1);
+  ASSERT_EQ(status, PROTON_OK);
+
+  char buf[PROTON_SIGNAL_STRING_VALUE_CAPACITY] = {0};
+  size_t len = 0;
+  status = access.get(PROTON_SIGNAL_STRING_VALUE_ID, buf, sizeof(buf), len);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_STREQ(buf, new_value);
+  EXPECT_EQ(len, strlen(new_value) + 1);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, GetDefaultBytes)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  uint8_t buf[PROTON_SIGNAL_DEFAULT_BYTES_CAPACITY] = {0};
+  size_t len = 0;
+  proton_status_e status = access.get(PROTON_SIGNAL_DEFAULT_BYTES_ID, buf, sizeof(buf), len);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(len, 3);
+  EXPECT_EQ(buf[0], 0);
+  EXPECT_EQ(buf[1], 1);
+  EXPECT_EQ(buf[2], 2);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, SetBytes)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  uint8_t new_value[] = {0xAA, 0xBB, 0xCC, 0xDD};
+  proton_status_e status = access.set(PROTON_SIGNAL_BYTES_VALUE_ID, new_value, sizeof(new_value));
+  ASSERT_EQ(status, PROTON_OK);
+
+  uint8_t buf[PROTON_SIGNAL_BYTES_VALUE_CAPACITY] = {0};
+  size_t len = 0;
+  status = access.get(PROTON_SIGNAL_BYTES_VALUE_ID, buf, sizeof(buf), len);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(len, sizeof(new_value));
+  EXPECT_EQ(memcmp(buf, new_value, len), 0);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalAccess, GetInvalidSignalId)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  SignalAccess access(&registry);
+
+  double value;
+  proton_status_e status = access.get(0x9999, value);
+  EXPECT_EQ(status, PROTON_ERROR);
+
+  free(registry.signal_registry);
+}
 
 int main(int argc, char ** argv)
 {


### PR DESCRIPTION
Part of the larger proton re-architecture [here](https://otto-ra.atlassian.net/wiki/spaces/PFT/pages/344948755/Proton+Reorganization+and+Core+Library) (internal CPR/OTTO employee eyes only 👀 )

Part 1 of 3 for proton_core's C++ wrapper.

This PR adds:
- `SignalAccess`: class for accessing the signal registry in a semi-generic way
- `Signal`: templated class for abstracting a signal (still requires raw pointer access to the registry)
- `SignalBase`: non-templated class for signals to live in containers
- `RegistryLock`: locking primitive for the registry lock for usage with `std::lock_guard`
- `ScopedLock`: locking primitive that locks in the constructor, and unlocks in destructor.
- `BundleAccess`: accessor for bundle API
- `PROTON_ENABLE_ALLOC` feature flag: 
  - Flag enables PC-level features for RTTI (for downcasting `SignalBase` to `Signal<T>`)
  - Enables usage of `std::function` with `BundleAccess` for lambdas and `std::bind` for decode callbacks.