### PR TITLE
Feature: test randomization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,9 +154,9 @@ jobs:
 
       - name: Run tests
         run: |
-          ctest --schedule-random --test-dir build_core --output-on-failure
-        env:
-          GTEST_SHUFFLE: 1
+          SEED=$(( (RANDOM % 99999) + 1 ))
+          echo "GTest random seed: $SEED"
+          GTEST_SHUFFLE=1 GTEST_RANDOM_SEED=$SEED ctest --schedule-random --test-dir build_core --output-on-failure
 
       - name: Generate core coverage report
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,9 @@ jobs:
 
       - name: Run tests
         run: |
-          ctest --test-dir build_core --output-on-failure
+          ctest --schedule-random --test-dir build_core --output-on-failure
+        env:
+          GTEST_SHUFFLE: 1
 
       - name: Generate core coverage report
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Run tests
         run: |
-          SEED=$(( (RANDOM % 99999) + 1 ))
+          SEED=$(( (${{ github.run_id }} % 99999) + 1 ))
           echo "GTest random seed: $SEED"
           GTEST_SHUFFLE=1 GTEST_RANDOM_SEED=$SEED ctest --schedule-random --test-dir build_core --output-on-failure
 


### PR DESCRIPTION
Calculate a random seed (between 1 and 99999) for gtest, print it and pass it as an arg. This will randomize the test execution order to make testing more robust. The order of test executables has also been randomized through `ctest --schedule-random`