### PR TITLE
Fix: reduce registry memory usage

### DIFF
--- a/core/generator_scripts/resources/target_node.c.jinja
+++ b/core/generator_scripts/resources/target_node.c.jinja
@@ -63,5 +63,5 @@ static const proton_endpoint_t g_target_connections[] = {
 proton_core_node_t g_target_node = {
   .id = PROTON_NODE_{{ target | upper }}_ID,
   .destination_peers = g_target_connections,
-  .num_peers = (sizeof(g_target_connections) / sizeof(g_target_connections[0])),
+  .num_peers = (uint8_t)(sizeof(g_target_connections) / sizeof(g_target_connections[0])),
 };

--- a/core/generator_scripts/resources/target_registry.c.jinja
+++ b/core/generator_scripts/resources/target_registry.c.jinja
@@ -17,6 +17,7 @@
  */
 
 #include "proton/registry.h"
+#include "proton/proton_config.h"
 #include "target_registry_sizes.h"
 #include "target_registry_ids.h"
 
@@ -101,7 +102,7 @@ static proton_Signal g_encode_decode_buffer[{{ max_bundle_signals.value if max_b
 
 // Scratch buffer used as a temporary decode target for string/bytes signals
 // TODO manage the size of this buffer at build time
-static uint8_t g_signal_decode_scratch[1024];
+static uint8_t g_signal_decode_scratch[PROTON_SCRATCH_BUFFER_SIZE];
 
 proton_registry_t g_proton_registry = {
   .bundle_table = g_bundle_table,
@@ -111,5 +112,5 @@ proton_registry_t g_proton_registry = {
   .signal_registry = g_signal_registry,
   .signal_count = PROTON_SIGNAL_REGISTRY_SIZE,
   .signal_scratch_buffer = g_signal_decode_scratch,
-  .signal_scratch_buffer_size = 1024,
+  .signal_scratch_buffer_size = PROTON_SCRATCH_BUFFER_SIZE,
 };

--- a/core/generator_scripts/resources/target_registry.c.jinja
+++ b/core/generator_scripts/resources/target_registry.c.jinja
@@ -60,17 +60,6 @@ uint8_t * g_signal_decode_buffers[PROTON_SIGNAL_REGISTRY_SIZE] = {
 {% endfor %}
 };
 
-// Capacities for signals that are repeated, such as strings and bytes
-const size_t g_signal_max_capacity[PROTON_SIGNAL_REGISTRY_SIZE] = {
-{% for signal in signals %}
-  {% if signal.type in ("string", "bytes") %}
-  PROTON_SIGNAL_{{ signal.name | upper }}_CAPACITY,
-  {% else %}
-  0,
-  {% endif %}
-{% endfor %}
-};
-
 signal_desc_t g_signal_registry[PROTON_SIGNAL_REGISTRY_SIZE] = {
 {% for signal in signals %}
   {
@@ -123,22 +112,16 @@ const id_to_index_t g_bundle_id_lut[PROTON_BUNDLE_REGISTRY_SIZE] = {
 {% endfor %}
 };
 
-// Per-bundle arrays of signals for encode/decode
+// Calculate max signals in any bundle for shared encode/decode buffer
+{% set max_bundle_signals = namespace(value=0) %}
 {% for bundle in bundles %}
-{% if bundle.signals | length > 0 %}
-static proton_Signal g_bundle_{{ bundle.name }}_signals[{{ bundle.signals | length }}] = {};
+{% if bundle.signals | length > max_bundle_signals.value %}
+{% set max_bundle_signals.value = bundle.signals | length %}
 {% endif %}
 {% endfor %}
 
-proton_Signal* g_bundle_signal_ptrs[PROTON_BUNDLE_REGISTRY_SIZE] = {
-{% for bundle in bundles %}
-{% if bundle.signals | length > 0 %}
-  g_bundle_{{ bundle.name }}_signals,
-{% else %}
-  NULL,
-{% endif %}
-{% endfor %}
-};
+// Shared encode/decode buffer sized to largest bundle
+static proton_Signal g_encode_decode_buffer[{{ max_bundle_signals.value if max_bundle_signals.value > 0 else 1 }}] = {};
 
 proton_bundle_cb_t g_bundle_callbacks[PROTON_BUNDLE_REGISTRY_SIZE] = {
 {% for bundle in bundles %}
@@ -154,12 +137,11 @@ proton_registry_t g_proton_registry = {
   .bundle_table = g_bundle_table,
   .bundle_id_lut = g_bundle_id_lut,
   .bundle_callbacks = g_bundle_callbacks,
-
   .bundle_count = PROTON_BUNDLE_REGISTRY_SIZE,
-  .bundle_signal_ptrs = g_bundle_signal_ptrs,
+  .encode_decode_buffer = g_encode_decode_buffer,
+  .encode_decode_buffer_count = {{ max_bundle_signals.value if max_bundle_signals.value > 0 else 1 }},
   .signal_registry = g_signal_registry,
   .signal_id_lut = g_signal_id_lut,
-  .signal_max_capacity = g_signal_max_capacity,
   .signal_decode_buffers = g_signal_decode_buffers,
   .signal_count = PROTON_SIGNAL_REGISTRY_SIZE,
   .signal_scratch_buffer = g_signal_decode_scratch,

--- a/core/generator_scripts/resources/target_registry.c.jinja
+++ b/core/generator_scripts/resources/target_registry.c.jinja
@@ -89,6 +89,7 @@ bundle_desc_t g_bundle_table[PROTON_BUNDLE_REGISTRY_SIZE] = {
     .last_send_ms = 0,
     .period_ms = {{ bundle.period_ms }},
     .send_now = false,
+    .callback = { NULL, NULL },
   },
 {% endif %}
 {% endfor %}
@@ -114,12 +115,6 @@ const id_to_index_t g_bundle_id_lut[PROTON_BUNDLE_REGISTRY_SIZE] = {
 // Shared encode/decode buffer sized to largest bundle
 static proton_Signal g_encode_decode_buffer[{{ max_bundle_signals.value if max_bundle_signals.value > 0 else 1 }}] = {};
 
-proton_bundle_cb_t g_bundle_callbacks[PROTON_BUNDLE_REGISTRY_SIZE] = {
-{% for bundle in bundles %}
-  { NULL, NULL },
-{% endfor %}
-};
-
 // Scratch buffer used as a temporary decode target for string/bytes signals
 // TODO manage the size of this buffer at build time
 static uint8_t g_signal_decode_scratch[1024];
@@ -127,7 +122,6 @@ static uint8_t g_signal_decode_scratch[1024];
 proton_registry_t g_proton_registry = {
   .bundle_table = g_bundle_table,
   .bundle_id_lut = g_bundle_id_lut,
-  .bundle_callbacks = g_bundle_callbacks,
   .bundle_count = PROTON_BUNDLE_REGISTRY_SIZE,
   .encode_decode_buffer = g_encode_decode_buffer,
   .encode_decode_buffer_count = {{ max_bundle_signals.value if max_bundle_signals.value > 0 else 1 }},

--- a/core/generator_scripts/resources/target_registry.c.jinja
+++ b/core/generator_scripts/resources/target_registry.c.jinja
@@ -49,17 +49,6 @@ static uint8_t g_signal_{{ signal.name }}_decode_buffer[PROTON_SIGNAL_{{ signal.
 {% endif %}
 {% endfor %}
 
-// Lookup for these decode space buffers
-uint8_t * g_signal_decode_buffers[PROTON_SIGNAL_REGISTRY_SIZE] = {
-{% for signal in signals %}
-{% if signal.type in ("string", "bytes") %}
-  g_signal_{{ signal.name }}_decode_buffer,
-{% else %}
-  NULL,
-{% endif %}
-{% endfor %}
-};
-
 signal_desc_t g_signal_registry[PROTON_SIGNAL_REGISTRY_SIZE] = {
 {% for signal in signals %}
   {
@@ -70,9 +59,11 @@ signal_desc_t g_signal_registry[PROTON_SIGNAL_REGISTRY_SIZE] = {
     {% if signal.type in ("string", "bytes") %}
     .signal.signal.{{ signal.type }}_value = g_signal_{{ signal.name }}_buffer,
     .value_size = PROTON_SIGNAL_{{ signal.name | upper }}_CAPACITY,
+    .signal_decode_buffer = g_signal_{{ signal.name }}_decode_buffer,
     {% else %}
     .signal.signal.{{ signal.type }}_value = {{ signal.value }},
     .value_size = sizeof({{ signal.type }}{% if "int" in signal.type %}_t{% endif %}),
+    .signal_decode_buffer = NULL,
     {% endif %}
   },
 {% endfor %}
@@ -142,7 +133,6 @@ proton_registry_t g_proton_registry = {
   .encode_decode_buffer_count = {{ max_bundle_signals.value if max_bundle_signals.value > 0 else 1 }},
   .signal_registry = g_signal_registry,
   .signal_id_lut = g_signal_id_lut,
-  .signal_decode_buffers = g_signal_decode_buffers,
   .signal_count = PROTON_SIGNAL_REGISTRY_SIZE,
   .signal_scratch_buffer = g_signal_decode_scratch,
   .signal_scratch_buffer_size = 1024,

--- a/core/generator_scripts/resources/target_registry.c.jinja
+++ b/core/generator_scripts/resources/target_registry.c.jinja
@@ -26,13 +26,6 @@
 
 {# this is the top-level signals array, already filtered by signals we care about and ordered by ID #}
 
-// Signal ID's are not contiguous, so use a lookup to find them in the registry
-const id_to_index_t g_signal_id_lut[PROTON_SIGNAL_REGISTRY_SIZE] = {
-{% for signal in signals %}
-  { .id = {{ signal.id }}, .idx = {{ loop.index0 }} },
-{% endfor %}
-};
-
 // Buffers for signals that are repeated, such as strings and bytes
 {% for signal in signals %}
 {% if signal.type == "string" %}
@@ -95,15 +88,6 @@ bundle_desc_t g_bundle_table[PROTON_BUNDLE_REGISTRY_SIZE] = {
 {% endfor %}
 };
 
-// Bundle ID's are not contiguous, so use a lookup to find them in the registry
-const id_to_index_t g_bundle_id_lut[PROTON_BUNDLE_REGISTRY_SIZE] = {
-{% for bundle in bundles %}
-{% if target in bundle.producers or target in bundle.consumers %}
-  { .id = {{ bundle.id }}, .idx = {{ loop.index0 }} },
-{% endif %}
-{% endfor %}
-};
-
 // Calculate max signals in any bundle for shared encode/decode buffer
 {% set max_bundle_signals = namespace(value=0) %}
 {% for bundle in bundles %}
@@ -121,12 +105,10 @@ static uint8_t g_signal_decode_scratch[1024];
 
 proton_registry_t g_proton_registry = {
   .bundle_table = g_bundle_table,
-  .bundle_id_lut = g_bundle_id_lut,
   .bundle_count = PROTON_BUNDLE_REGISTRY_SIZE,
   .encode_decode_buffer = g_encode_decode_buffer,
   .encode_decode_buffer_count = {{ max_bundle_signals.value if max_bundle_signals.value > 0 else 1 }},
   .signal_registry = g_signal_registry,
-  .signal_id_lut = g_signal_id_lut,
   .signal_count = PROTON_SIGNAL_REGISTRY_SIZE,
   .signal_scratch_buffer = g_signal_decode_scratch,
   .signal_scratch_buffer_size = 1024,

--- a/core/include/proton/node_manager.h
+++ b/core/include/proton/node_manager.h
@@ -55,11 +55,11 @@ extern "C"
   {
     uint32_t id;
     const proton_endpoint_t * destination_peers;
-    size_t num_peers;
+    uint8_t num_peers;
     proton_registry_t * registry;
     uint32_t pending_triggers[PROTON_MAX_PENDING_TRIGGERS];
-    size_t trigger_head;
-    size_t trigger_tail;
+    uint8_t trigger_head;
+    uint8_t trigger_tail;
   } proton_core_node_t;  // TODO change to proton_node_t as part of protonc deprecation
 
   /**

--- a/core/include/proton/proton_config.h
+++ b/core/include/proton/proton_config.h
@@ -19,6 +19,10 @@
 #ifndef PROTON_CONFIG_HPP
 #define PROTON_CONFIG_HPP
 
+#ifndef PROTON_SCRATCH_BUFFER_SIZE
+#define PROTON_SCRATCH_BUFFER_SIZE 512
+#endif
+
 // Default to embedded mode (no allocation/RTTI) if not specified
 #ifndef PROTON_ENABLE_ALLOC
 #define PROTON_ENABLE_ALLOC 0

--- a/core/include/proton/registry.h
+++ b/core/include/proton/registry.h
@@ -189,11 +189,11 @@ extern "C"
     const proton_registry_t * registry, uint32_t bundle_id, size_t * slot_idx);
 
   /**
-   * Get the buffer for encoding/decoding signals from a bundle, by bundle ID or lookup index if known
+   * Get the buffer for encoding/decoding signals from a bundle
    * @return pointer to the buffer, or NULL if not found
    */
   proton_Signal * proton_registry_get_bundle_encode_decode_buffer(
-    const proton_registry_t * registry, uint32_t bundle_id, const size_t * bundle_lut_idx);
+    const proton_registry_t * registry);
 
   /**
    * Get the callback for a bundle

--- a/core/include/proton/registry.h
+++ b/core/include/proton/registry.h
@@ -119,6 +119,8 @@ extern "C"
     // NOTE: 0 means no period, and will only be sent if triggered or directly requested in the node manager API
     uint32_t period_ms;
     bool send_now;
+    // Callback for when this bundle is successfully decoded
+    proton_bundle_cb_t callback;
   } bundle_desc_t;
 
   /**
@@ -145,7 +147,6 @@ extern "C"
     // Since the bundle IDs are not contiguous, the bundle_id_lut is used to find the index of a bundle descriptor
     bundle_desc_t * bundle_table;
     const id_to_index_t * bundle_id_lut;
-    proton_bundle_cb_t * bundle_callbacks;
     size_t bundle_count;
 
     // Shared buffer for encoding/decoding signals in bundles.

--- a/core/include/proton/registry.h
+++ b/core/include/proton/registry.h
@@ -146,9 +146,10 @@ extern "C"
     proton_bundle_cb_t * bundle_callbacks;
     size_t bundle_count;
 
-    // Buffers for encoding/decoding signals per bundle.
-    // This is NOT the actual value of the signal, but a temporary buffer space.
-    proton_Signal ** bundle_signal_ptrs;
+    // Shared buffer for encoding/decoding signals in bundles.
+    // Sized to fit the largest bundle's signal count.
+    proton_Signal * encode_decode_buffer;
+    size_t encode_decode_buffer_count;
 
     // Signal metadata and state
     // signal_registry is the table of all signal descriptors,
@@ -156,8 +157,6 @@ extern "C"
     signal_desc_t * signal_registry;
     // Similar to how bundle ID's are not contiguous, signal ID's are looked up in a similar manner
     const id_to_index_t * signal_id_lut;
-    // For signals that are bytes/string types, the max capacity of the signal is specified here
-    const size_t * signal_max_capacity;
     // Space for string/bytes signals
     uint8_t ** signal_decode_buffers;
     size_t signal_count;

--- a/core/include/proton/registry.h
+++ b/core/include/proton/registry.h
@@ -124,15 +124,6 @@ extern "C"
   } bundle_desc_t;
 
   /**
-   * Mapping from ID to index in the signal or bundle registries.
-   */
-  typedef struct signal_id_to_index
-  {
-    uint32_t id;
-    uint32_t idx;
-  } id_to_index_t;
-
-  /**
    * proton_registry_t is a memory representation of the entire set of bundles and signals for a node.
    * It is used as the source of truth for encoding and decoding bundles, and can be queried for signal values.
    * The registry is provided by a user pre-populated with bundle and signal mapping
@@ -144,9 +135,7 @@ extern "C"
   {
     // Bundle metadata and state
     // bundle_table is the table of all bundle descriptors
-    // Since the bundle IDs are not contiguous, the bundle_id_lut is used to find the index of a bundle descriptor
     bundle_desc_t * bundle_table;
-    const id_to_index_t * bundle_id_lut;
     size_t bundle_count;
 
     // Shared buffer for encoding/decoding signals in bundles.
@@ -158,8 +147,7 @@ extern "C"
     // signal_registry is the table of all signal descriptors,
     // It also contains the current value of each signal. It is written to after a bundle is successfully decoded
     signal_desc_t * signal_registry;
-    // Similar to how bundle ID's are not contiguous, signal ID's are looked up in a similar manner
-    const id_to_index_t * signal_id_lut;
+
     size_t signal_count;
     // Scratch-pad buffer for encoding/decoding string/bytes signals
     uint8_t * signal_scratch_buffer;

--- a/core/include/proton/registry.h
+++ b/core/include/proton/registry.h
@@ -102,6 +102,8 @@ extern "C"
     // For strings and bytes, capacity of the signal. For other types, this is the size of the internal type.
     size_t value_size;
     proton_Signal signal;
+    // Decode buffer for string/bytes signals (NULL for other types)
+    uint8_t * signal_decode_buffer;
   } signal_desc_t;
 
   /**
@@ -157,8 +159,6 @@ extern "C"
     signal_desc_t * signal_registry;
     // Similar to how bundle ID's are not contiguous, signal ID's are looked up in a similar manner
     const id_to_index_t * signal_id_lut;
-    // Space for string/bytes signals
-    uint8_t ** signal_decode_buffers;
     size_t signal_count;
     // Scratch-pad buffer for encoding/decoding string/bytes signals
     uint8_t * signal_scratch_buffer;

--- a/core/include/proton/registry.h
+++ b/core/include/proton/registry.h
@@ -88,7 +88,7 @@ extern "C"
   typedef struct proton_id_list
   {
     const uint32_t * ids;
-    size_t count;
+    uint8_t count;
   } proton_id_list_t;
 
   /**
@@ -100,7 +100,7 @@ extern "C"
     uint32_t id;
     proton_signal_type_e type;
     // For strings and bytes, capacity of the signal. For other types, this is the size of the internal type.
-    size_t value_size;
+    uint16_t value_size;
     proton_Signal signal;
     // Decode buffer for string/bytes signals (NULL for other types)
     uint8_t * signal_decode_buffer;
@@ -136,22 +136,22 @@ extern "C"
     // Bundle metadata and state
     // bundle_table is the table of all bundle descriptors
     bundle_desc_t * bundle_table;
-    size_t bundle_count;
+    uint16_t bundle_count;
 
     // Shared buffer for encoding/decoding signals in bundles.
     // Sized to fit the largest bundle's signal count.
     proton_Signal * encode_decode_buffer;
-    size_t encode_decode_buffer_count;
+    uint8_t encode_decode_buffer_count;
 
     // Signal metadata and state
     // signal_registry is the table of all signal descriptors,
     // It also contains the current value of each signal. It is written to after a bundle is successfully decoded
     signal_desc_t * signal_registry;
 
-    size_t signal_count;
+    uint16_t signal_count;
     // Scratch-pad buffer for encoding/decoding string/bytes signals
     uint8_t * signal_scratch_buffer;
-    size_t signal_scratch_buffer_size;
+    uint16_t signal_scratch_buffer_size;
 
     // Optional mutex callbacks
     proton_registry_mutex_cb_t mutex_handles;

--- a/core/src/encode_decode.c
+++ b/core/src/encode_decode.c
@@ -192,7 +192,7 @@ static bool proton_decode_bundle_cb(pb_istream_t * istream, const pb_field_t * f
         {
           return false;
         }
-        size_t capacity = registry->signal_max_capacity[signal_registry_idx];
+        size_t capacity = registry->signal_registry[signal_registry_idx].value_size;
         if (scratch_buf.len > capacity)
         {
           return false;
@@ -208,7 +208,7 @@ static bool proton_decode_bundle_cb(pb_istream_t * istream, const pb_field_t * f
         {
           return false;
         }
-        size_t capacity = registry->signal_max_capacity[signal_registry_idx];
+        size_t capacity = registry->signal_registry[signal_registry_idx].value_size;
         if (scratch_buf.len > capacity)
         {
           return false;

--- a/core/src/encode_decode.c
+++ b/core/src/encode_decode.c
@@ -187,7 +187,8 @@ static bool proton_decode_bundle_cb(pb_istream_t * istream, const pb_field_t * f
     {
       case proton_Signal_string_value_tag:
       {
-        char * decode_buf = (char *)registry->signal_decode_buffers[signal_registry_idx];
+        char * decode_buf =
+          (char *)registry->signal_registry[signal_registry_idx].signal_decode_buffer;
         if (decode_buf == NULL)
         {
           return false;
@@ -203,7 +204,7 @@ static bool proton_decode_bundle_cb(pb_istream_t * istream, const pb_field_t * f
       }
       case proton_Signal_bytes_value_tag:
       {
-        uint8_t * decode_buf = registry->signal_decode_buffers[signal_registry_idx];
+        uint8_t * decode_buf = registry->signal_registry[signal_registry_idx].signal_decode_buffer;
         if (decode_buf == NULL)
         {
           return false;

--- a/core/src/encode_decode.c
+++ b/core/src/encode_decode.c
@@ -129,8 +129,7 @@ static bool proton_decode_bundle_cb(pb_istream_t * istream, const pb_field_t * f
   }
 
   size_t signal_count = bundle_desc->signal_ids.count;
-  proton_Signal * bundle_signals =
-    proton_registry_get_bundle_encode_decode_buffer(registry, bundle_id, &bundle_lut);
+  proton_Signal * bundle_signals = proton_registry_get_bundle_encode_decode_buffer(registry);
 
   if (bundle_signals == NULL)
   {
@@ -275,9 +274,7 @@ static proton_status_e check_stream_bytes_left(const pb_istream_t * stream)
 static proton_status_e proton_decode_bundle(
   proton_registry_t * registry, proton_Bundle * bundle, const pb_istream_t * stream)
 {
-  size_t bundle_slot = 0;
-  const bundle_desc_t * bundle_desc =
-    proton_registry_get_bundle(registry, bundle->id, &bundle_slot);
+  const bundle_desc_t * bundle_desc = proton_registry_get_bundle(registry, bundle->id, NULL);
   // This bundle doesn't exist
   if (bundle_desc == NULL)
   {
@@ -285,8 +282,7 @@ static proton_status_e proton_decode_bundle(
   }
 
   // Set signals in registry based on decoded values
-  proton_Signal * bundle_signals =
-    proton_registry_get_bundle_encode_decode_buffer(registry, bundle->id, &bundle_slot);
+  proton_Signal * bundle_signals = proton_registry_get_bundle_encode_decode_buffer(registry);
   for (size_t i = 0; i < bundle_desc->signal_ids.count; i++)
   {
     proton_Signal * signal_ptr = &bundle_signals[i];

--- a/core/src/node_manager.c
+++ b/core/src/node_manager.c
@@ -126,8 +126,8 @@ proton_status_e proton_node_receive(proton_core_node_t * node, const uint8_t * b
       }
       else
       {
-        // Get the bundle callback directly from the slot ID to save time
-        proton_bundle_cb_t * callback_desc = &node->registry->bundle_callbacks[slot_id];
+        // Get the bundle callback directly from the bundle descriptor
+        proton_bundle_cb_t * callback_desc = &node->registry->bundle_table[slot_id].callback;
 
         if (callback_desc != NULL && callback_desc->cb != NULL)
         {

--- a/core/src/registry.c
+++ b/core/src/registry.c
@@ -107,7 +107,7 @@ proton_bundle_cb_t * proton_registry_get_bundle_callback(
   {
     if (registry->bundle_id_lut[i].id == bundle_id)
     {
-      return &registry->bundle_callbacks[registry->bundle_id_lut[i].idx];
+      return &registry->bundle_table[registry->bundle_id_lut[i].idx].callback;
     }
   }
 
@@ -121,8 +121,8 @@ void proton_registry_set_bundle_callback(
   {
     if (registry->bundle_id_lut[i].id == bundle_id)
     {
-      registry->bundle_callbacks[registry->bundle_id_lut[i].idx].cb = bundle_cb;
-      registry->bundle_callbacks[registry->bundle_id_lut[i].idx].arg = context;
+      registry->bundle_table[registry->bundle_id_lut[i].idx].callback.cb = bundle_cb;
+      registry->bundle_table[registry->bundle_id_lut[i].idx].callback.arg = context;
     }
   }
 }

--- a/core/src/registry.c
+++ b/core/src/registry.c
@@ -77,14 +77,13 @@ const bundle_desc_t * proton_registry_get_bundle(
   {
     for (size_t i = 0; i < registry->bundle_count; i++)
     {
-      if (registry->bundle_id_lut[i].id == bundle_id)
+      if (registry->bundle_table[i].bundle_id == bundle_id)
       {
-        size_t idx = registry->bundle_id_lut[i].idx;
         if (slot_idx)
         {
-          *slot_idx = idx;
+          *slot_idx = i;
         }
-        return &registry->bundle_table[idx];
+        return &registry->bundle_table[i];
       }
     }
   }
@@ -102,9 +101,9 @@ proton_bundle_cb_t * proton_registry_get_bundle_callback(
 {
   for (size_t i = 0; i < registry->bundle_count; i++)
   {
-    if (registry->bundle_id_lut[i].id == bundle_id)
+    if (registry->bundle_table[i].bundle_id == bundle_id)
     {
-      return &registry->bundle_table[registry->bundle_id_lut[i].idx].callback;
+      return &registry->bundle_table[i].callback;
     }
   }
 
@@ -116,10 +115,10 @@ void proton_registry_set_bundle_callback(
 {
   for (size_t i = 0; i < registry->bundle_count; i++)
   {
-    if (registry->bundle_id_lut[i].id == bundle_id)
+    if (registry->bundle_table[i].bundle_id == bundle_id)
     {
-      registry->bundle_table[registry->bundle_id_lut[i].idx].callback.cb = bundle_cb;
-      registry->bundle_table[registry->bundle_id_lut[i].idx].callback.arg = context;
+      registry->bundle_table[i].callback.cb = bundle_cb;
+      registry->bundle_table[i].callback.arg = context;
     }
   }
 }
@@ -129,9 +128,9 @@ void proton_registry_set_bundle_period(
 {
   for (size_t i = 0; i < registry->bundle_count; i++)
   {
-    if (registry->bundle_id_lut[i].id == bundle_id)
+    if (registry->bundle_table[i].bundle_id == bundle_id)
     {
-      registry->bundle_table[registry->bundle_id_lut[i].idx].period_ms = period_ms;
+      registry->bundle_table[i].period_ms = period_ms;
       return;
     }
   }
@@ -142,14 +141,13 @@ signal_desc_t * proton_registry_get_signal(
 {
   for (size_t i = 0; i < registry->signal_count; i++)
   {
-    if (registry->signal_id_lut[i].id == signal_id)
+    if (registry->signal_registry[i].id == signal_id)
     {
-      size_t idx = registry->signal_id_lut[i].idx;
       if (registry_idx)
       {
-        *registry_idx = idx;
+        *registry_idx = i;
       }
-      return &registry->signal_registry[idx];
+      return &registry->signal_registry[i];
     }
   }
 

--- a/core/src/registry.c
+++ b/core/src/registry.c
@@ -92,11 +92,8 @@ const bundle_desc_t * proton_registry_get_bundle(
   return NULL;
 }
 
-proton_Signal * proton_registry_get_bundle_encode_decode_buffer(
-  const proton_registry_t * registry, uint32_t bundle_id, const size_t * bundle_lut_idx)
+proton_Signal * proton_registry_get_bundle_encode_decode_buffer(const proton_registry_t * registry)
 {
-  (void)bundle_id;       // Unused — shared buffer serves all bundles
-  (void)bundle_lut_idx;  // Unused — shared buffer serves all bundles
   return registry->encode_decode_buffer;
 }
 

--- a/core/src/registry.c
+++ b/core/src/registry.c
@@ -95,20 +95,9 @@ const bundle_desc_t * proton_registry_get_bundle(
 proton_Signal * proton_registry_get_bundle_encode_decode_buffer(
   const proton_registry_t * registry, uint32_t bundle_id, const size_t * bundle_lut_idx)
 {
-  if (bundle_lut_idx != NULL)
-  {
-    return registry->bundle_signal_ptrs[*bundle_lut_idx];
-  }
-
-  for (size_t i = 0; i < registry->bundle_count; i++)
-  {
-    if (registry->bundle_id_lut[i].id == bundle_id)
-    {
-      return registry->bundle_signal_ptrs[registry->bundle_id_lut[i].idx];
-    }
-  }
-
-  return NULL;
+  (void)bundle_id;       // Unused — shared buffer serves all bundles
+  (void)bundle_lut_idx;  // Unused — shared buffer serves all bundles
+  return registry->encode_decode_buffer;
 }
 
 proton_bundle_cb_t * proton_registry_get_bundle_callback(
@@ -291,7 +280,7 @@ proton_status_e proton_signal_set_string(
   {
     return PROTON_ERROR;
   }
-  if (registry->signal_max_capacity[idx] < len)
+  if (desc->value_size < len)
   {
     return PROTON_INSUFFICIENT_BUFFER_ERROR;
   }
@@ -336,7 +325,7 @@ proton_status_e proton_signal_set_bytes(
   {
     return PROTON_ERROR;
   }
-  if (registry->signal_max_capacity[idx] < len)
+  if (desc->value_size < len)
   {
     return PROTON_INSUFFICIENT_BUFFER_ERROR;
   }

--- a/core/tests/core/encode_decode_test.cpp
+++ b/core/tests/core/encode_decode_test.cpp
@@ -24,8 +24,6 @@
 #include "target_registry_sizes.h"
 #include "utils.hpp"
 
-static constexpr size_t BUFFER_SIZE = 1024;
-
 extern proton_registry_t g_proton_registry;
 
 /**

--- a/core/tests/core/multi_node_test.cpp
+++ b/core/tests/core/multi_node_test.cpp
@@ -25,8 +25,6 @@
 #include <gtest/gtest.h>
 #include <cstring>
 
-static constexpr size_t BUFFER_SIZE = 1024;
-
 extern proton_registry_t g_proton_registry;
 extern proton_core_node_t g_target_node;
 

--- a/core/tests/core/node_manager_test.cpp
+++ b/core/tests/core/node_manager_test.cpp
@@ -25,8 +25,6 @@
 #include <gtest/gtest.h>
 #include <cstring>
 
-static constexpr size_t BUFFER_SIZE = 1024;
-
 extern proton_registry_t g_proton_registry;
 extern proton_core_node_t g_target_node;
 

--- a/core/tests/core/node_manager_test.cpp
+++ b/core/tests/core/node_manager_test.cpp
@@ -40,12 +40,12 @@ protected:
   void SetUp() override
   {
     // Reset shared bundle table state before each test.
-    // bundle_table is not deep-copied by copy_default_registry, so this affects
-    // both the global and any per-test registry copy.
+    // bundle_table is now deep-copied by copy_default_registry.
     for (size_t i = 0; i < g_proton_registry.bundle_count; i++)
     {
       g_proton_registry.bundle_table[i].last_send_ms = 0;
       g_proton_registry.bundle_table[i].send_now = false;
+      g_proton_registry.bundle_table[i].callback = {NULL, NULL};
     }
     registry_ = copy_default_registry(&g_proton_registry);
     node_ = copy_default_node(&g_target_node);
@@ -60,7 +60,7 @@ protected:
   void TearDown() override
   {
     free(registry_.signal_registry);
-    free(registry_.bundle_callbacks);
+    free(registry_.bundle_table);
     registry_.mutex_handles.arg = nullptr;
     registry_.mutex_handles.lock = nullptr;
     registry_.mutex_handles.unlock = nullptr;

--- a/core/tests/core/periodic_bundle_test.cpp
+++ b/core/tests/core/periodic_bundle_test.cpp
@@ -25,8 +25,6 @@
 #include <gtest/gtest.h>
 #include <cstring>
 
-static constexpr size_t BUFFER_SIZE = 1024;
-
 extern proton_registry_t g_proton_registry;
 extern proton_core_node_t g_target_node;
 

--- a/core/tests/core/periodic_bundle_test.cpp
+++ b/core/tests/core/periodic_bundle_test.cpp
@@ -40,12 +40,12 @@ protected:
   void SetUp() override
   {
     // Reset shared bundle table state before each test.
-    // bundle_table is not deep-copied by copy_default_registry, so this affects
-    // both the global and any per-test registry copy.
+    // bundle_table is now deep-copied by copy_default_registry.
     for (size_t i = 0; i < g_proton_registry.bundle_count; i++)
     {
       g_proton_registry.bundle_table[i].last_send_ms = 0;
       g_proton_registry.bundle_table[i].send_now = false;
+      g_proton_registry.bundle_table[i].callback = {NULL, NULL};
     }
     registry_ = copy_default_registry(&g_proton_registry);
     node_ = copy_default_node(&g_target_node);
@@ -55,7 +55,7 @@ protected:
   void TearDown() override
   {
     free(registry_.signal_registry);
-    free(registry_.bundle_callbacks);
+    free(registry_.bundle_table);
   }
 
   proton_registry_t registry_;

--- a/core/tests/core/utils.hpp
+++ b/core/tests/core/utils.hpp
@@ -29,6 +29,8 @@ extern "C"
 {
 #endif
 
+  static constexpr size_t BUFFER_SIZE = 1024;
+
   proton_registry_t copy_default_registry(proton_registry_t * original_registry)
   {
     proton_registry_t copy = *original_registry;

--- a/core/tests/core/utils.hpp
+++ b/core/tests/core/utils.hpp
@@ -40,13 +40,13 @@ extern "C"
       sizeof(signal_desc_t) * copy.signal_count);
     copy.signal_registry = signal_registry_copy;
 
-    // Deep copy bundle callbacks
-    proton_bundle_cb_t * bundle_cb_copy =
-      (proton_bundle_cb_t *)malloc(sizeof(proton_bundle_cb_t) * copy.bundle_count);
+    // Deep copy bundle table (includes callbacks and mutable state like last_send_ms)
+    bundle_desc_t * bundle_table_copy =
+      (bundle_desc_t *)malloc(sizeof(bundle_desc_t) * copy.bundle_count);
     memcpy(
-      bundle_cb_copy, original_registry->bundle_callbacks,
-      sizeof(proton_bundle_cb_t) * copy.bundle_count);
-    copy.bundle_callbacks = bundle_cb_copy;
+      bundle_table_copy, original_registry->bundle_table,
+      sizeof(bundle_desc_t) * copy.bundle_count);
+    copy.bundle_table = bundle_table_copy;
 
     return copy;
   }

--- a/cpp/tests/node_manager_test.cpp
+++ b/cpp/tests/node_manager_test.cpp
@@ -56,6 +56,7 @@ protected:
     {
       g_proton_registry.bundle_table[i].last_send_ms = 0;
       g_proton_registry.bundle_table[i].send_now = false;
+      g_proton_registry.bundle_table[i].callback = {NULL, NULL};
     }
     registry_ = copy_default_registry(&g_proton_registry);
     node_ = copy_default_node(&g_target_node);
@@ -65,7 +66,7 @@ protected:
   void TearDown() override
   {
     free(registry_.signal_registry);
-    free(registry_.bundle_callbacks);
+    free(registry_.bundle_table);
     if (node_.num_peers > 0)
     {
       free(const_cast<proton_endpoint_t *>(node_.destination_peers));

--- a/cpp/tests/node_manager_test.cpp
+++ b/cpp/tests/node_manager_test.cpp
@@ -40,8 +40,6 @@ extern proton_core_node_t g_target_node;
 
 using namespace proton;
 
-static constexpr size_t BUFFER_SIZE = 1024;
-
 // -----------------------------------------------------------------------
 // Test fixture
 // -----------------------------------------------------------------------


### PR DESCRIPTION
While writing the C++ registry generator I found that the registry uses too much memory for my liking. So I found some places to cut down on memory usage.