### PR TITLE
Feature: CORE-37265: node builder

### DIFF
--- a/core/generator_scripts/resources/target_registry.c.jinja
+++ b/core/generator_scripts/resources/target_registry.c.jinja
@@ -53,10 +53,12 @@ signal_desc_t g_signal_registry[PROTON_SIGNAL_REGISTRY_SIZE] = {
     {% if signal.type in ("string", "bytes") %}
     .signal.signal.{{ signal.type }}_value = g_signal_{{ signal.name }}_buffer,
     .value_size = PROTON_SIGNAL_{{ signal.name | upper }}_CAPACITY,
+    .capacity = PROTON_SIGNAL_{{ signal.name | upper }}_CAPACITY,
     .signal_decode_buffer = g_signal_{{ signal.name }}_decode_buffer,
     {% else %}
     .signal.signal.{{ signal.type }}_value = {{ signal.value }},
     .value_size = sizeof({{ signal.type }}{% if "int" in signal.type %}_t{% endif %}),
+    .capacity = 0,
     .signal_decode_buffer = NULL,
     {% endif %}
   },

--- a/core/generator_scripts/resources/target_registry.c.jinja
+++ b/core/generator_scripts/resources/target_registry.c.jinja
@@ -54,12 +54,18 @@ signal_desc_t g_signal_registry[PROTON_SIGNAL_REGISTRY_SIZE] = {
     .signal.signal.{{ signal.type }}_value = g_signal_{{ signal.name }}_buffer,
     .value_size = PROTON_SIGNAL_{{ signal.name | upper }}_CAPACITY,
     .capacity = PROTON_SIGNAL_{{ signal.name | upper }}_CAPACITY,
-    .signal_decode_buffer = g_signal_{{ signal.name }}_decode_buffer,
+    .signal_decode_buffer = {
+      .data = g_signal_{{ signal.name }}_decode_buffer,
+      .len = PROTON_SIGNAL_{{ signal.name | upper }}_CAPACITY,
+    },
     {% else %}
     .signal.signal.{{ signal.type }}_value = {{ signal.value }},
     .value_size = sizeof({{ signal.type }}{% if "int" in signal.type %}_t{% endif %}),
     .capacity = 0,
-    .signal_decode_buffer = NULL,
+    .signal_decode_buffer = {
+      .data = NULL,
+      .len = 0,
+    },
     {% endif %}
   },
 {% endfor %}

--- a/core/include/proton/registry.h
+++ b/core/include/proton/registry.h
@@ -99,8 +99,10 @@ extern "C"
   {
     uint32_t id;
     proton_signal_type_e type;
-    // For strings and bytes, capacity of the signal. For other types, this is the size of the internal type.
+    // For strings and bytes, current size of the signal. For other types, this is the size of the internal type.
     uint16_t value_size;
+    // For strings and bytes, max size of the signal. Others, 0
+    uint16_t capacity;
     proton_Signal signal;
     // Decode buffer for string/bytes signals (NULL for other types)
     uint8_t * signal_decode_buffer;

--- a/core/include/proton/registry.h
+++ b/core/include/proton/registry.h
@@ -218,6 +218,24 @@ extern "C"
    */
   proton_signal_type_e proton_get_type_from_tag(pb_size_t tag);
 
+  /**
+   * Get the signal tag from type
+   * @return the protobuf tag
+   */
+  pb_size_t proton_get_tag_from_type(proton_signal_type_e type);
+
+  /**
+   * Get the size of a value for a given type, for string/bytes types, return given capacity
+   * @return the size of the value for the type, or capacity for string/bytes types
+   */
+  size_t get_signal_value_size(proton_signal_type_e type, size_t capacity);
+
+  /**
+   * Get the signal type from a string representation. Used for parsing config files
+   * @return the signal type, or PROTON_INVALID_TYPE if the string does not match a valid type
+   */
+  proton_signal_type_e string_to_signal_type(const char * type_str);
+
   /*
    * Typed signal accessors.
    *

--- a/core/include/proton/registry.h
+++ b/core/include/proton/registry.h
@@ -105,7 +105,7 @@ extern "C"
     uint16_t capacity;
     proton_Signal signal;
     // Decode buffer for string/bytes signals (NULL for other types)
-    uint8_t * signal_decode_buffer;
+    proton_buffer_t signal_decode_buffer;
   } signal_desc_t;
 
   /**

--- a/core/include/proton/registry.h
+++ b/core/include/proton/registry.h
@@ -228,7 +228,7 @@ extern "C"
    * Get the size of a value for a given type, for string/bytes types, return given capacity
    * @return the size of the value for the type, or capacity for string/bytes types
    */
-  size_t get_signal_value_size(proton_signal_type_e type, size_t capacity);
+  uint16_t get_signal_value_size(proton_signal_type_e type, uint32_t capacity);
 
   /**
    * Get the signal type from a string representation. Used for parsing config files

--- a/core/src/encode_decode.c
+++ b/core/src/encode_decode.c
@@ -184,39 +184,33 @@ static bool proton_decode_bundle_cb(pb_istream_t * istream, const pb_field_t * f
 
     switch (incoming.which_signal)
     {
+      case proton_Signal_bytes_value_tag:
       case proton_Signal_string_value_tag:
       {
-        char * decode_buf =
-          (char *)registry->signal_registry[signal_registry_idx].signal_decode_buffer;
-        if (decode_buf == NULL)
+        proton_buffer_t * decode_buf =
+          &registry->signal_registry[signal_registry_idx].signal_decode_buffer;
+        if (decode_buf->data == NULL)
         {
           return false;
         }
-        size_t capacity = registry->signal_registry[signal_registry_idx].value_size;
+        size_t capacity = registry->signal_registry[signal_registry_idx].capacity;
         if (scratch_buf.len > capacity)
         {
           return false;
         }
-        memcpy(decode_buf, scratch_buf.data, scratch_buf.len);
-        signal->signal.string_value = decode_buf;
+        memcpy(decode_buf->data, scratch_buf.data, scratch_buf.len);
+        if (incoming.which_signal == proton_Signal_bytes_value_tag)
+        {
+          signal->signal.bytes_value = decode_buf->data;
+        }
+        else
+        {
+          signal->signal.string_value = decode_buf->data;
+        }
+        decode_buf->len = scratch_buf.len;
         break;
       }
-      case proton_Signal_bytes_value_tag:
-      {
-        uint8_t * decode_buf = registry->signal_registry[signal_registry_idx].signal_decode_buffer;
-        if (decode_buf == NULL)
-        {
-          return false;
-        }
-        size_t capacity = registry->signal_registry[signal_registry_idx].value_size;
-        if (scratch_buf.len > capacity)
-        {
-          return false;
-        }
-        memcpy(decode_buf, scratch_buf.data, scratch_buf.len);
-        signal->signal.bytes_value = decode_buf;
-        break;
-      }
+
       default:
       {
         memcpy(&signal->signal, &incoming.signal, sizeof(incoming.signal));
@@ -300,7 +294,8 @@ static proton_status_e proton_decode_bundle(
     {
       // value pointer in union points to the decode buffer — copy content into registry
       const void * src = signal_ptr->signal.string_value;  // same union slot as bytes_value
-      memcpy(desc->signal.signal.string_value, src, desc->value_size);
+      memcpy(desc->signal.signal.string_value, src, desc->signal_decode_buffer.len);
+      desc->value_size = desc->signal_decode_buffer.len;
     }
     else
     {

--- a/core/src/registry.c
+++ b/core/src/registry.c
@@ -125,39 +125,39 @@ uint16_t get_signal_value_size(proton_signal_type_e type, uint32_t capacity)
 
 proton_signal_type_e string_to_signal_type(const char * type_str)
 {
-  if (strcmp(type_str, "double") == 0)
+  if (strncmp(type_str, "double", strlen("double")) == 0)
   {
     return PROTON_DOUBLE;
   }
-  else if (strcmp(type_str, "float") == 0)
+  else if (strncmp(type_str, "float", strlen("float")) == 0)
   {
     return PROTON_FLOAT;
   }
-  else if (strcmp(type_str, "int32") == 0)
+  else if (strncmp(type_str, "int32", strlen("int32")) == 0)
   {
     return PROTON_INT32;
   }
-  else if (strcmp(type_str, "int64") == 0)
+  else if (strncmp(type_str, "int64", strlen("int64")) == 0)
   {
     return PROTON_INT64;
   }
-  else if (strcmp(type_str, "uint32") == 0)
+  else if (strncmp(type_str, "uint32", strlen("uint32")) == 0)
   {
     return PROTON_UINT32;
   }
-  else if (strcmp(type_str, "uint64") == 0)
+  else if (strncmp(type_str, "uint64", strlen("uint64")) == 0)
   {
     return PROTON_UINT64;
   }
-  else if (strcmp(type_str, "bool") == 0)
+  else if (strncmp(type_str, "bool", strlen("bool")) == 0)
   {
     return PROTON_BOOL;
   }
-  else if (strcmp(type_str, "string") == 0)
+  else if (strncmp(type_str, "string", strlen("string")) == 0)
   {
     return PROTON_STRING;
   }
-  else if (strcmp(type_str, "bytes") == 0)
+  else if (strncmp(type_str, "bytes", strlen("bytes")) == 0)
   {
     return PROTON_BYTES;
   }

--- a/core/src/registry.c
+++ b/core/src/registry.c
@@ -70,6 +70,103 @@ proton_signal_type_e proton_get_type_from_tag(pb_size_t tag)
   }
 }
 
+pb_size_t proton_get_tag_from_type(proton_signal_type_e type)
+{
+  switch (type)
+  {
+    case PROTON_DOUBLE:
+      return proton_Signal_double_value_tag;
+    case PROTON_FLOAT:
+      return proton_Signal_float_value_tag;
+    case PROTON_INT32:
+      return proton_Signal_int32_value_tag;
+    case PROTON_INT64:
+      return proton_Signal_int64_value_tag;
+    case PROTON_UINT32:
+      return proton_Signal_uint32_value_tag;
+    case PROTON_UINT64:
+      return proton_Signal_uint64_value_tag;
+    case PROTON_BOOL:
+      return proton_Signal_bool_value_tag;
+    case PROTON_STRING:
+      return proton_Signal_string_value_tag;
+    case PROTON_BYTES:
+      return proton_Signal_bytes_value_tag;
+    default:
+      return 0;
+  }
+}
+
+size_t get_signal_value_size(proton_signal_type_e type, uint32_t capacity)
+{
+  switch (type)
+  {
+    case PROTON_DOUBLE:
+      return sizeof(double);
+    case PROTON_FLOAT:
+      return sizeof(float);
+    case PROTON_INT32:
+      return sizeof(int32_t);
+    case PROTON_INT64:
+      return sizeof(int64_t);
+    case PROTON_UINT32:
+      return sizeof(uint32_t);
+    case PROTON_UINT64:
+      return sizeof(uint64_t);
+    case PROTON_BOOL:
+      return sizeof(bool);
+    case PROTON_STRING:
+    case PROTON_BYTES:
+      return capacity;
+    default:
+      return 0;
+  }
+}
+
+proton_signal_type_e string_to_signal_type(const char * type_str)
+{
+  if (strcmp(type_str, "double") == 0)
+  {
+    return PROTON_DOUBLE;
+  }
+  else if (strcmp(type_str, "float") == 0)
+  {
+    return PROTON_FLOAT;
+  }
+  else if (strcmp(type_str, "int32") == 0)
+  {
+    return PROTON_INT32;
+  }
+  else if (strcmp(type_str, "int64") == 0)
+  {
+    return PROTON_INT64;
+  }
+  else if (strcmp(type_str, "uint32") == 0)
+  {
+    return PROTON_UINT32;
+  }
+  else if (strcmp(type_str, "uint64") == 0)
+  {
+    return PROTON_UINT64;
+  }
+  else if (strcmp(type_str, "bool") == 0)
+  {
+    return PROTON_BOOL;
+  }
+  else if (strcmp(type_str, "string") == 0)
+  {
+    return PROTON_STRING;
+  }
+  else if (strcmp(type_str, "bytes") == 0)
+  {
+    return PROTON_BYTES;
+  }
+  else
+  {
+    return PROTON_INVALID_TYPE;
+  }
+}
+
 const bundle_desc_t * proton_registry_get_bundle(
   const proton_registry_t * registry, uint32_t bundle_id, size_t * slot_idx)
 {

--- a/core/src/registry.c
+++ b/core/src/registry.c
@@ -384,7 +384,7 @@ proton_status_e proton_signal_set_string(
     string_len += 1;  // Account for null terminator
   }
 
-  if (desc->capacity < string_len)
+  if (len > desc->capacity || desc->capacity < string_len)
   {
     return PROTON_INSUFFICIENT_BUFFER_ERROR;
   }

--- a/core/src/registry.c
+++ b/core/src/registry.c
@@ -328,23 +328,23 @@ static proton_status_e proton_signal_get_buffer(
     return PROTON_ERROR;
   }
 
-  size_t signal_capacity = desc->value_size;
+  size_t signal_size = desc->value_size;
   if (expected_tag == proton_Signal_string_value_tag)
   {
-    signal_capacity = strnlen(desc->signal.signal.string_value, desc->value_size);
-    if (signal_capacity < desc->value_size)
+    signal_size = strnlen(desc->signal.signal.string_value, desc->capacity);
+    if (signal_size < desc->capacity)
     {
-      signal_capacity += 1;  // Account for null terminator if not present
+      signal_size += 1;  // Account for null terminator if not present
     }
   }
 
-  if (capacity < signal_capacity)
+  if (capacity < signal_size)
   {
     return PROTON_INSUFFICIENT_BUFFER_ERROR;
   }
 
-  memcpy(buf, desc->signal.signal.string_value, signal_capacity);
-  *out_len = signal_capacity;
+  memcpy(buf, desc->signal.signal.string_value, signal_size);
+  *out_len = signal_size;
   return PROTON_OK;
 }
 
@@ -373,22 +373,25 @@ proton_status_e proton_signal_set_string(
   {
     return PROTON_ERROR;
   }
-  if (desc->value_size < len)
-  {
-    return PROTON_INSUFFICIENT_BUFFER_ERROR;
-  }
 
-  size_t capacity = strnlen(str, len);
-  if (capacity == len)
+  size_t string_len = strnlen(str, len);
+  if (string_len == len)
   {
     return PROTON_ERROR;  // Input string is not null-terminated within the specified length
   }
   else
   {
-    capacity += 1;  // Account for null terminator
+    string_len += 1;  // Account for null terminator
   }
 
-  memcpy(desc->signal.signal.string_value, str, capacity);
+  if (desc->capacity < string_len)
+  {
+    return PROTON_INSUFFICIENT_BUFFER_ERROR;
+  }
+
+  desc->value_size = string_len;
+
+  memcpy(desc->signal.signal.string_value, str, string_len);
   return PROTON_OK;
 }
 
@@ -417,7 +420,7 @@ proton_status_e proton_signal_set_bytes(
   {
     return PROTON_ERROR;
   }
-  if (desc->value_size < len)
+  if (desc->capacity < len)
   {
     return PROTON_INSUFFICIENT_BUFFER_ERROR;
   }

--- a/core/src/registry.c
+++ b/core/src/registry.c
@@ -327,23 +327,24 @@ static proton_status_e proton_signal_get_buffer(
   {
     return PROTON_ERROR;
   }
-  if (capacity < desc->value_size)
+
+  size_t signal_capacity = desc->value_size;
+  if (expected_tag == proton_Signal_string_value_tag)
+  {
+    signal_capacity = strnlen(desc->signal.signal.string_value, desc->value_size);
+    if (signal_capacity < desc->value_size)
+    {
+      signal_capacity += 1;  // Account for null terminator if not present
+    }
+  }
+
+  if (capacity < signal_capacity)
   {
     return PROTON_INSUFFICIENT_BUFFER_ERROR;
   }
 
-  size_t string_capacity = desc->value_size;
-  if (expected_tag == proton_Signal_string_value_tag)
-  {
-    string_capacity = strnlen(desc->signal.signal.string_value, desc->value_size);
-    if (string_capacity < desc->value_size)
-    {
-      string_capacity += 1;  // Account for null terminator if not present
-    }
-  }
-
-  memcpy(buf, desc->signal.signal.string_value, string_capacity);
-  *out_len = string_capacity;
+  memcpy(buf, desc->signal.signal.string_value, signal_capacity);
+  *out_len = signal_capacity;
   return PROTON_OK;
 }
 
@@ -388,7 +389,6 @@ proton_status_e proton_signal_set_string(
   }
 
   memcpy(desc->signal.signal.string_value, str, capacity);
-  desc->value_size = len;
   return PROTON_OK;
 }
 

--- a/core/src/registry.c
+++ b/core/src/registry.c
@@ -97,7 +97,7 @@ pb_size_t proton_get_tag_from_type(proton_signal_type_e type)
   }
 }
 
-size_t get_signal_value_size(proton_signal_type_e type, uint32_t capacity)
+uint16_t get_signal_value_size(proton_signal_type_e type, uint32_t capacity)
 {
   switch (type)
   {

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(${PROJECT_NAME}
   src/signal_access.cpp
   src/node_builder/config.cpp
   src/node_builder/config_tree.cpp
+  src/node_builder/generator.cpp
 )
 
 target_include_directories(${PROJECT_NAME}
@@ -197,6 +198,19 @@ if (PROTON_BUILD_TESTS)
     ${CMAKE_CURRENT_SOURCE_DIR}/../core/tests/core
   )
 
+  add_executable(node_builder_generator_test_cpp
+    tests/node_builder_generator_test.cpp
+  )
+
+  target_link_libraries(node_builder_generator_test_cpp PUBLIC
+    GTest::gtest_main
+    proton::proton_core_cpp
+  )
+
+  target_include_directories(node_builder_generator_test_cpp PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/../core/tests/core
+  )
+
   include(GoogleTest)
   gtest_discover_tests(registry_test_cpp)
   gtest_discover_tests(lock_test_cpp)
@@ -207,6 +221,9 @@ if (PROTON_BUILD_TESTS)
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests
   )
   gtest_discover_tests(node_builder_config_tree_test_cpp
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests
+  )
+  gtest_discover_tests(node_builder_generator_test_cpp
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests
   )
 endif()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -211,6 +211,19 @@ if (PROTON_BUILD_TESTS)
     ${CMAKE_CURRENT_SOURCE_DIR}/../core/tests/core
   )
 
+  add_executable(node_builder_generator_round_trip_test_cpp
+    tests/node_builder_generator_round_trip_test.cpp
+  )
+
+  target_link_libraries(node_builder_generator_round_trip_test_cpp PUBLIC
+    GTest::gtest_main
+    proton::proton_core_cpp
+  )
+
+  target_include_directories(node_builder_generator_round_trip_test_cpp PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/../core/tests/core
+  )
+
   include(GoogleTest)
   gtest_discover_tests(registry_test_cpp)
   gtest_discover_tests(lock_test_cpp)
@@ -224,6 +237,9 @@ if (PROTON_BUILD_TESTS)
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests
   )
   gtest_discover_tests(node_builder_generator_test_cpp
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests
+  )
+  gtest_discover_tests(node_builder_generator_round_trip_test_cpp
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests
   )
 endif()

--- a/cpp/include/protoncpp/node_builder/config.hpp
+++ b/cpp/include/protoncpp/node_builder/config.hpp
@@ -92,11 +92,32 @@ inline constexpr std::string_view SERIAL = "serial";
 
 struct SignalConfig
 {
+  SignalConfig() = default;
+  SignalConfig(std::string name, uint32_t id, std::string type_string)
+  : name(std::move(name)),
+    id(id),
+    type_string(std::move(type_string)),
+    value_size(0),
+    capacity(0),
+    has_default_value(false)
+  {
+  }
+  SignalConfig(std::string name, uint32_t id, std::string type_string, uint16_t capacity)
+  : name(std::move(name)),
+    id(id),
+    type_string(std::move(type_string)),
+    value_size(capacity),
+    capacity(capacity),
+    has_default_value(false)
+  {
+  }
+
   std::string name;
-  uint32_t id;
+  uint32_t id{};
   std::string type_string;
-  uint32_t capacity;
-  bool has_default_value;
+  uint16_t value_size{};
+  uint16_t capacity{};
+  bool has_default_value{};
   ConfigValue value;
 };
 

--- a/cpp/include/protoncpp/node_builder/generator.hpp
+++ b/cpp/include/protoncpp/node_builder/generator.hpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Rockwell Automation Technologies, Inc., All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Tom Wallis (thomas.wallis@rockwellautomation.com)
+ */
+
+#ifndef PROTON_NODE_BUILDER_GENERATOR_HPP
+#define PROTON_NODE_BUILDER_GENERATOR_HPP
+
+#include "proton/proton_config.h"
+
+#if PROTON_NODE_BUILDER
+
+#include "proton/node_manager.h"
+#include "protoncpp/node_builder/config.hpp"
+
+namespace proton::node_builder
+{
+
+Config filter_for_target(const Config & config, const std::string & target_name);
+
+}  // namespace proton::node_builder
+
+#endif  // PROTON_NODE_BUILDER
+#endif  // PROTON_NODE_BUILDER_GENERATOR_HPP

--- a/cpp/include/protoncpp/node_builder/generator.hpp
+++ b/cpp/include/protoncpp/node_builder/generator.hpp
@@ -116,7 +116,9 @@ private:
   std::vector<proton_Signal> bundle_encode_decode_buffer_;
   std::vector<signal_desc_t> signal_registry_;
 
-  // Owned storage for string/bytes signal decode buffer
+  // Owned storage for string/bytes signal value buffer (where actual values are stored)
+  std::vector<std::vector<uint8_t>> signal_value_buffer_storage_;
+  // Owned storage for string/bytes signal decode buffer (temporary decode space)
   std::vector<std::vector<uint8_t>> signal_decode_buffer_storage_;
   std::vector<uint8_t> signal_scratch_buffer_;
 

--- a/cpp/include/protoncpp/node_builder/generator.hpp
+++ b/cpp/include/protoncpp/node_builder/generator.hpp
@@ -29,6 +29,8 @@
 #include <cstdint>
 #include <format>
 #include <map>
+#include <memory>
+#include <mutex>
 #include <span>
 #include <sstream>
 #include <string>
@@ -101,6 +103,10 @@ private:
   void init_registry();
   void init_node(const Config & config, const std::string & target_name);
 
+  // Locking methods
+  static proton_status_e lock(void * mutex, void * ctx);
+  static proton_status_e unlock(void * mutex, void * ctx);
+
   // Owned storage for endpoint peers
   std::vector<proton_endpoint_t> node_destination_peers_;
 
@@ -121,6 +127,9 @@ private:
   // Owned storage for string/bytes signal decode buffer (temporary decode space)
   std::vector<std::vector<uint8_t>> signal_decode_buffer_storage_;
   std::vector<uint8_t> signal_scratch_buffer_;
+
+  // Registry locking
+  mutable std::unique_ptr<std::mutex> mtx_ = std::make_unique<std::mutex>();
 
   // The actual node and registry structs (point into owned storage above)
   proton_core_node_t node_{};

--- a/cpp/include/protoncpp/node_builder/generator.hpp
+++ b/cpp/include/protoncpp/node_builder/generator.hpp
@@ -109,23 +109,15 @@ private:
   std::map<uint32_t, std::vector<uint32_t>> bundle_consumer_ids_;
   std::map<uint32_t, std::vector<uint32_t>> bundle_signal_ids_;
 
-  // Owned storage for bundle descriptors and LUT
+  // Owned storage for bundle descriptors
   std::vector<bundle_desc_t> bundle_table_;
-  std::vector<id_to_index_t> bundle_id_lut_;
-  std::vector<proton_bundle_cb_t> bundle_callbacks_;
 
   // Owned storage for bundle encode/decode signal pointers
-  std::vector<std::vector<proton_Signal>> bundle_encode_decode_buffers_;
-  std::vector<proton_Signal *> bundle_signal_ptrs_;
-
-  // Owned storage for signal descriptors and LUT
+  std::vector<proton_Signal> bundle_encode_decode_buffer_;
   std::vector<signal_desc_t> signal_registry_;
-  std::vector<id_to_index_t> signal_id_lut_;
-  std::vector<size_t> signal_max_capacity_;
 
-  // Owned storage for string/bytes signal decode buffers
+  // Owned storage for string/bytes signal decode buffer
   std::vector<std::vector<uint8_t>> signal_decode_buffer_storage_;
-  std::vector<uint8_t *> signal_decode_buffers_;
   std::vector<uint8_t> signal_scratch_buffer_;
 
   // The actual node and registry structs (point into owned storage above)

--- a/cpp/include/protoncpp/node_builder/generator.hpp
+++ b/cpp/include/protoncpp/node_builder/generator.hpp
@@ -28,6 +28,7 @@
 
 #include <format>
 #include <span>
+#include <sstream>
 #include <string>
 #include <unordered_set>
 
@@ -44,13 +45,23 @@ void find_duplicates(const std::span<T> & items, const std::string & name)
   {
     if (!seen.insert(i).second)
     {
-      duplicates.insert(i)
+      duplicates.insert(i);
     }
   }
 
   if (!duplicates.empty())
   {
-    throw NodeBuilderException(std::format("Error: {} contains duplicates {}", name, duplicates));
+    std::ostringstream oss;
+    oss << "{";
+    bool first = true;
+    for (const auto & d : duplicates)
+    {
+      if (!first) oss << ", ";
+      oss << d;
+      first = false;
+    }
+    oss << "}";
+    throw NodeBuilderException(std::format("Error: {} contains duplicates {}", name, oss.str()));
   }
 }
 

--- a/cpp/include/protoncpp/node_builder/generator.hpp
+++ b/cpp/include/protoncpp/node_builder/generator.hpp
@@ -26,11 +26,14 @@
 #include "proton/node_manager.h"
 #include "protoncpp/node_builder/config.hpp"
 
+#include <cstdint>
 #include <format>
+#include <map>
 #include <span>
 #include <sstream>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 namespace proton::node_builder
 {
@@ -56,7 +59,10 @@ void find_duplicates(const std::span<T> & items, const std::string & name)
     bool first = true;
     for (const auto & d : duplicates)
     {
-      if (!first) oss << ", ";
+      if (!first)
+      {
+        oss << ", ";
+      }
       oss << d;
       first = false;
     }
@@ -67,6 +73,65 @@ void find_duplicates(const std::span<T> & items, const std::string & name)
 
 void validate(const Config & config);
 Config filter_for_target(const Config & config, const std::string & target_name);
+
+class GeneratedNode
+{
+public:
+  explicit GeneratedNode() = default;
+  explicit GeneratedNode(const Config & config, const std::string & target_name);
+  ~GeneratedNode() = default;
+
+  // Non-copyable, move-only
+  GeneratedNode(const GeneratedNode &) = delete;
+  GeneratedNode & operator=(const GeneratedNode &) = delete;
+  GeneratedNode(GeneratedNode &&) = default;
+  GeneratedNode & operator=(GeneratedNode &&) = default;
+
+  // Accessors
+  proton_core_node_t * node() { return &node_; }
+  const proton_core_node_t * node() const { return &node_; }
+  proton_registry_t * registry() { return &registry_; }
+  const proton_registry_t * registry() const { return &registry_; }
+
+private:
+  // Generation methods - called during construction
+  void generate_endpoints(const Config & config, const std::string & target_name);
+  void generate_signals(const Config & config);
+  void generate_bundles(const Config & config);
+  void init_registry();
+  void init_node(const Config & config, const std::string & target_name);
+
+  // Owned storage for endpoint peers
+  std::vector<proton_endpoint_t> node_destination_peers_;
+
+  // Owned storage for bundle ID lists (producer_ids, consumer_ids, signal_ids per bundle)
+  std::map<uint32_t, std::vector<uint32_t>> bundle_producer_ids_;
+  std::map<uint32_t, std::vector<uint32_t>> bundle_consumer_ids_;
+  std::map<uint32_t, std::vector<uint32_t>> bundle_signal_ids_;
+
+  // Owned storage for bundle descriptors and LUT
+  std::vector<bundle_desc_t> bundle_table_;
+  std::vector<id_to_index_t> bundle_id_lut_;
+  std::vector<proton_bundle_cb_t> bundle_callbacks_;
+
+  // Owned storage for bundle encode/decode signal pointers
+  std::vector<std::vector<proton_Signal>> bundle_encode_decode_buffers_;
+  std::vector<proton_Signal *> bundle_signal_ptrs_;
+
+  // Owned storage for signal descriptors and LUT
+  std::vector<signal_desc_t> signal_registry_;
+  std::vector<id_to_index_t> signal_id_lut_;
+  std::vector<size_t> signal_max_capacity_;
+
+  // Owned storage for string/bytes signal decode buffers
+  std::vector<std::vector<uint8_t>> signal_decode_buffer_storage_;
+  std::vector<uint8_t *> signal_decode_buffers_;
+  std::vector<uint8_t> signal_scratch_buffer_;
+
+  // The actual node and registry structs (point into owned storage above)
+  proton_core_node_t node_{};
+  proton_registry_t registry_{};
+};
 
 }  // namespace proton::node_builder
 

--- a/cpp/include/protoncpp/node_builder/generator.hpp
+++ b/cpp/include/protoncpp/node_builder/generator.hpp
@@ -26,9 +26,35 @@
 #include "proton/node_manager.h"
 #include "protoncpp/node_builder/config.hpp"
 
+#include <format>
+#include <span>
+#include <string>
+#include <unordered_set>
+
 namespace proton::node_builder
 {
 
+template <typename T>
+void find_duplicates(const std::span<T> & items, const std::string & name)
+{
+  std::unordered_set<T> seen;
+  std::unordered_set<T> duplicates;
+
+  for (const auto & i : items)
+  {
+    if (!seen.insert(i).second)
+    {
+      duplicates.insert(i)
+    }
+  }
+
+  if (!duplicates.empty())
+  {
+    throw NodeBuilderException(std::format("Error: {} contains duplicates {}", name, duplicates));
+  }
+}
+
+void validate(const Config & config);
 Config filter_for_target(const Config & config, const std::string & target_name);
 
 }  // namespace proton::node_builder

--- a/cpp/src/node_builder/generator.cpp
+++ b/cpp/src/node_builder/generator.cpp
@@ -177,6 +177,258 @@ Config filter_for_target(const Config & config, const std::string & target_name)
   return filtered_config;
 }
 
+static proton_transport_type_e string_to_transport(const std::string & t_type)
+{
+  if (t_type == transport_types::UDP4)
+  {
+    return TRANSPORT_TYPE_UDP4;
+  }
+  else if (t_type == transport_types::SERIAL)
+  {
+    return TRANSPORT_TYPE_SERIAL;
+  }
+  else
+  {
+    throw NodeBuilderException(std::format("Transport type is invalid: {}", t_type));
+  }
+}
+
+// ============================================================================
+// GeneratedNode implementation
+// ============================================================================
+
+GeneratedNode::GeneratedNode(const Config & config, const std::string & target_name)
+{
+  generate_endpoints(config, target_name);
+  generate_signals(config);
+  generate_bundles(config);
+  init_registry();
+  init_node(config, target_name);
+}
+
+void GeneratedNode::generate_endpoints(const Config & config, const std::string & target_name)
+{
+  for (const auto & [name, node] : config.nodes)
+  {
+    if (name != target_name)
+    {
+      for (const auto & [id, endpoint] : node.endpoints)
+      {
+        proton_endpoint_t ep = {
+          .node_id = node.id,
+          .endpoint_id = endpoint.id,
+          .transport_type = string_to_transport(endpoint.type)};
+        node_destination_peers_.push_back(ep);
+      }
+    }
+  }
+}
+
+void GeneratedNode::generate_signals(const Config & config)
+{
+  signal_registry_.reserve(config.signals.size());
+  signal_id_lut_.reserve(config.signals.size());
+  signal_max_capacity_.reserve(config.signals.size());
+  signal_decode_buffer_storage_.reserve(config.signals.size());
+  signal_decode_buffers_.reserve(config.signals.size());
+
+  size_t max_scratch_size = 0;
+
+  for (size_t idx = 0; idx < config.signals.size(); idx++)
+  {
+    const auto & signal_cfg = config.signals[idx];
+    proton_signal_type_e sig_type = string_to_signal_type(signal_cfg.type_string.c_str());
+    if (sig_type == PROTON_INVALID_TYPE)
+    {
+      throw NodeBuilderException(std::format("Signal type is invalid: {}", signal_cfg.type_string));
+    }
+
+    size_t value_size = get_signal_value_size(sig_type, signal_cfg.capacity);
+
+    // Create signal descriptor
+    signal_desc_t sig_desc = {
+      .id = signal_cfg.id,
+      .type = sig_type,
+      .value_size = value_size,
+      .signal = proton_Signal_init_zero};
+
+    sig_desc.signal.which_signal = proton_get_tag_from_type(sig_type);
+
+    // Set default value if provided
+    if (signal_cfg.has_default_value)
+    {
+      ConfigNode value_node(signal_cfg.value);
+      switch (sig_type)
+      {
+        case PROTON_DOUBLE:
+          sig_desc.signal.signal.double_value = value_node.as_double();
+          break;
+        case PROTON_FLOAT:
+          sig_desc.signal.signal.float_value = static_cast<float>(value_node.as_double());
+          break;
+        case PROTON_INT32:
+          sig_desc.signal.signal.int32_value = static_cast<int32_t>(value_node.as_int64());
+          break;
+        case PROTON_INT64:
+          sig_desc.signal.signal.int64_value = value_node.as_int64();
+          break;
+        case PROTON_UINT32:
+          sig_desc.signal.signal.uint32_value = static_cast<uint32_t>(value_node.as_uint64());
+          break;
+        case PROTON_UINT64:
+          sig_desc.signal.signal.uint64_value = value_node.as_uint64();
+          break;
+        case PROTON_BOOL:
+          sig_desc.signal.signal.bool_value = value_node.as_bool();
+          break;
+        case PROTON_STRING:
+        case PROTON_BYTES:
+          // String/bytes default values handled separately via decode buffers
+          break;
+        default:
+          break;
+      }
+    }
+
+    signal_registry_.push_back(sig_desc);
+
+    // Create ID to index lookup entry
+    id_to_index_t lut_entry = {.id = signal_cfg.id, .idx = static_cast<uint32_t>(idx)};
+    signal_id_lut_.push_back(lut_entry);
+
+    // Track capacity for string/bytes types
+    signal_max_capacity_.push_back(signal_cfg.capacity);
+
+    // Allocate decode buffer for string/bytes signals
+    if (sig_type == PROTON_STRING || sig_type == PROTON_BYTES)
+    {
+      signal_decode_buffer_storage_.emplace_back(signal_cfg.capacity, 0);
+      max_scratch_size = std::max(max_scratch_size, static_cast<size_t>(signal_cfg.capacity));
+    }
+    else
+    {
+      signal_decode_buffer_storage_.emplace_back();  // Empty vector for non-string/bytes
+    }
+  }
+
+  // Build pointer array for decode buffers
+  for (auto & buf : signal_decode_buffer_storage_)
+  {
+    signal_decode_buffers_.push_back(buf.empty() ? nullptr : buf.data());
+  }
+
+  // Allocate scratch buffer (largest string/bytes capacity)
+  if (max_scratch_size > 0)
+  {
+    signal_scratch_buffer_.resize(max_scratch_size, 0);
+  }
+}
+
+void GeneratedNode::generate_bundles(const Config & config)
+{
+  ProducerConsumerIds prod_con_ids = set_producer_consumer_ids(config);
+  bundle_producer_ids_ = std::move(prod_con_ids.producer_ids);
+  bundle_consumer_ids_ = std::move(prod_con_ids.consumer_ids);
+
+  bundle_table_.reserve(config.bundles.size());
+  bundle_id_lut_.reserve(config.bundles.size());
+  bundle_callbacks_.reserve(config.bundles.size());
+  bundle_encode_decode_buffers_.reserve(config.bundles.size());
+
+  for (size_t idx = 0; idx < config.bundles.size(); idx++)
+  {
+    const auto & bundle_cfg = config.bundles[idx];
+
+    // Store signal IDs for this bundle
+    bundle_signal_ids_[bundle_cfg.id] = bundle_cfg.signals;
+
+    // Create bundle descriptor
+    bundle_desc_t bundle_desc = {
+      .bundle_id = bundle_cfg.id,
+      .producer_ids =
+        {
+          .ids = bundle_producer_ids_[bundle_cfg.id].data(),
+          .count = bundle_producer_ids_[bundle_cfg.id].size(),
+        },
+      .consumer_ids =
+        {
+          .ids = bundle_consumer_ids_[bundle_cfg.id].data(),
+          .count = bundle_consumer_ids_[bundle_cfg.id].size(),
+        },
+      .signal_ids =
+        {
+          .ids = bundle_signal_ids_[bundle_cfg.id].data(),
+          .count = bundle_signal_ids_[bundle_cfg.id].size(),
+        },
+      .last_send_ms = 0,
+      .period_ms = bundle_cfg.period_ms,
+      .send_now = false};
+    bundle_table_.push_back(bundle_desc);
+
+    // Create ID to index lookup entry
+    id_to_index_t lut_entry = {.id = bundle_cfg.id, .idx = static_cast<uint32_t>(idx)};
+    bundle_id_lut_.push_back(lut_entry);
+
+    // Create empty callback entry
+    proton_bundle_cb_t cb = {.cb = nullptr, .arg = nullptr};
+    bundle_callbacks_.push_back(cb);
+
+    // Allocate encode/decode buffer for signals in this bundle
+    std::vector<proton_Signal> encode_decode_signals(
+      bundle_cfg.signals.size(), proton_Signal_init_zero);
+    bundle_encode_decode_buffers_.push_back(std::move(encode_decode_signals));
+  }
+
+  // Build pointer array for bundle signal pointers
+  bundle_signal_ptrs_.reserve(bundle_encode_decode_buffers_.size());
+  for (auto & buf : bundle_encode_decode_buffers_)
+  {
+    bundle_signal_ptrs_.push_back(buf.data());
+  }
+}
+
+void GeneratedNode::init_registry()
+{
+  // Bundle table and lookups
+  registry_.bundle_table = bundle_table_.data();
+  registry_.bundle_id_lut = bundle_id_lut_.data();
+  registry_.bundle_callbacks = bundle_callbacks_.data();
+  registry_.bundle_count = bundle_table_.size();
+  registry_.bundle_signal_ptrs = bundle_signal_ptrs_.data();
+
+  // Signal table and lookups
+  registry_.signal_registry = signal_registry_.data();
+  registry_.signal_id_lut = signal_id_lut_.data();
+  registry_.signal_max_capacity = signal_max_capacity_.data();
+  registry_.signal_decode_buffers = signal_decode_buffers_.data();
+  registry_.signal_count = signal_registry_.size();
+
+  // Scratch buffer for string/bytes encoding/decoding
+  registry_.signal_scratch_buffer =
+    signal_scratch_buffer_.empty() ? nullptr : signal_scratch_buffer_.data();
+  registry_.signal_scratch_buffer_size = signal_scratch_buffer_.size();
+
+  // No mutex by default (user can set if needed)
+  registry_.mutex_handles = {.lock = nullptr, .unlock = nullptr, .mutex = nullptr, .arg = nullptr};
+}
+
+void GeneratedNode::init_node(const Config & config, const std::string & target_name)
+{
+  node_.id = config.nodes.at(target_name).id;
+  node_.destination_peers =
+    node_destination_peers_.empty() ? nullptr : node_destination_peers_.data();
+  node_.num_peers = node_destination_peers_.size();
+  node_.registry = &registry_;
+  node_.trigger_head = 0;
+  node_.trigger_tail = 0;
+
+  // Initialize pending triggers to zero
+  for (size_t i = 0; i < PROTON_MAX_PENDING_TRIGGERS; i++)
+  {
+    node_.pending_triggers[i] = 0;
+  }
+}
+
 }  // namespace proton::node_builder
 
 #endif  // PROTON_NODE_BUILDER

--- a/cpp/src/node_builder/generator.cpp
+++ b/cpp/src/node_builder/generator.cpp
@@ -290,6 +290,7 @@ void GeneratedNode::generate_signals(const Config & config)
           // String/bytes default values handled separately via decode buffers
           break;
         default:
+          throw NodeBuilderException("Signal type is invalid");
           break;
       }
     }

--- a/cpp/src/node_builder/generator.cpp
+++ b/cpp/src/node_builder/generator.cpp
@@ -249,7 +249,11 @@ void GeneratedNode::generate_signals(const Config & config)
       .value_size = value_size,
       .capacity = signal_cfg.capacity,
       .signal = proton_Signal_init_zero,
-      .signal_decode_buffer = nullptr,
+      .signal_decode_buffer =
+        {
+          .data = nullptr,
+          .len = 0,
+        },
     };
 
     sig_desc.signal.which_signal = proton_get_tag_from_type(sig_type);
@@ -325,7 +329,8 @@ void GeneratedNode::generate_signals(const Config & config)
 
       // Decode buffer - temporary space for decoding incoming data
       signal_decode_buffer_storage_.emplace_back(signal_cfg.capacity, 0);
-      signal_registry_.back().signal_decode_buffer = signal_decode_buffer_storage_.back().data();
+      sig_desc.signal_decode_buffer.data = signal_decode_buffer_storage_.back().data();
+      sig_desc.signal_decode_buffer.len = signal_decode_buffer_storage_.back().size();
     }
     else
     {

--- a/cpp/src/node_builder/generator.cpp
+++ b/cpp/src/node_builder/generator.cpp
@@ -227,8 +227,9 @@ void GeneratedNode::generate_endpoints(const Config & config, const std::string 
 void GeneratedNode::generate_signals(const Config & config)
 {
   signal_registry_.reserve(config.signals.size());
+  signal_value_buffer_storage_.reserve(config.signals.size());
   signal_decode_buffer_storage_.reserve(config.signals.size());
-  signal_scratch_buffer_.reserve(PROTON_SCRATCH_BUFFER_SIZE);
+  signal_scratch_buffer_.resize(PROTON_SCRATCH_BUFFER_SIZE);
 
   for (size_t idx = 0; idx < config.signals.size(); idx++)
   {
@@ -246,6 +247,7 @@ void GeneratedNode::generate_signals(const Config & config)
       .id = signal_cfg.id,
       .type = sig_type,
       .value_size = value_size,
+      .capacity = signal_cfg.capacity,
       .signal = proton_Signal_init_zero,
       .signal_decode_buffer = nullptr,
     };
@@ -288,18 +290,50 @@ void GeneratedNode::generate_signals(const Config & config)
       }
     }
 
-    signal_registry_.push_back(sig_desc);
-
-    // Allocate decode buffer for string/bytes signals
+    // Allocate buffers for string/bytes signals
     if (sig_type == PROTON_STRING || sig_type == PROTON_BYTES)
     {
+      signal_value_buffer_storage_.emplace_back(signal_cfg.capacity, 0);
+
+      if (signal_cfg.has_default_value)
+      {
+        ConfigNode value_node(signal_cfg.value);
+        if (sig_type == PROTON_STRING)
+        {
+          std::memcpy(
+            signal_value_buffer_storage_.back().data(), value_node.as_string().c_str(),
+            value_node.as_string().size() + 1);
+          sig_desc.value_size = value_node.as_string().size() + 1;
+        }
+        else if (sig_type == PROTON_BYTES)
+        {
+          std::vector<uint8_t> bytes_value;
+          for (const auto & item : value_node)
+          {
+            bytes_value.push_back(static_cast<uint8_t>(item.as_uint32()));
+          }
+
+          std::memcpy(
+            signal_value_buffer_storage_.back().data(), bytes_value.data(), bytes_value.size());
+          sig_desc.value_size = bytes_value.size();
+        }
+      }
+
+      // Value buffer - where the actual signal value is stored
+      sig_desc.signal.signal.string_value =
+        reinterpret_cast<char *>(signal_value_buffer_storage_.back().data());
+
+      // Decode buffer - temporary space for decoding incoming data
       signal_decode_buffer_storage_.emplace_back(signal_cfg.capacity, 0);
-      sig_desc.signal_decode_buffer = signal_decode_buffer_storage_.back().data();
+      signal_registry_.back().signal_decode_buffer = signal_decode_buffer_storage_.back().data();
     }
     else
     {
+      signal_value_buffer_storage_.emplace_back();   // Empty vector for non-string/bytes
       signal_decode_buffer_storage_.emplace_back();  // Empty vector for non-string/bytes
     }
+
+    signal_registry_.push_back(sig_desc);
   }
 }
 
@@ -355,7 +389,7 @@ void GeneratedNode::generate_bundles(const Config & config)
   }
 
   // Build space for encode/decode buffer (largest bundle signal count)
-  bundle_encode_decode_buffer_.reserve(max_signal_count);
+  bundle_encode_decode_buffer_.resize(max_signal_count);
 }
 
 void GeneratedNode::init_registry()
@@ -367,6 +401,7 @@ void GeneratedNode::init_registry()
   // Signal table and lookups
   registry_.signal_registry = signal_registry_.data();
   registry_.encode_decode_buffer = bundle_encode_decode_buffer_.data();
+  registry_.encode_decode_buffer_count = bundle_encode_decode_buffer_.size();
   registry_.signal_count = signal_registry_.size();
 
   // Scratch buffer for string/bytes encoding/decoding

--- a/cpp/src/node_builder/generator.cpp
+++ b/cpp/src/node_builder/generator.cpp
@@ -415,8 +415,11 @@ void GeneratedNode::init_registry()
     signal_scratch_buffer_.empty() ? nullptr : signal_scratch_buffer_.data();
   registry_.signal_scratch_buffer_size = signal_scratch_buffer_.size();
 
-  // No mutex by default (user can set if needed)
-  registry_.mutex_handles = {.lock = nullptr, .unlock = nullptr, .mutex = nullptr, .arg = nullptr};
+  registry_.mutex_handles = {
+    .lock = GeneratedNode::lock,
+    .unlock = GeneratedNode::unlock,
+    .mutex = mtx_.get(),
+    .arg = nullptr};
 }
 
 void GeneratedNode::init_node(const Config & config, const std::string & target_name)
@@ -434,6 +437,24 @@ void GeneratedNode::init_node(const Config & config, const std::string & target_
   {
     node_.pending_triggers[i] = 0;
   }
+}
+
+proton_status_e GeneratedNode::lock(void * mutex, void * ctx)
+{
+  (void)ctx;
+  std::mutex * mtx = static_cast<std::mutex *>(mutex);
+  mtx->lock();
+
+  return PROTON_OK;
+}
+
+proton_status_e GeneratedNode::unlock(void * mutex, void * ctx)
+{
+  (void)ctx;
+  std::mutex * mtx = static_cast<std::mutex *>(mutex);
+  mtx->unlock();
+
+  return PROTON_OK;
 }
 
 }  // namespace proton::node_builder

--- a/cpp/src/node_builder/generator.cpp
+++ b/cpp/src/node_builder/generator.cpp
@@ -133,7 +133,6 @@ Config filter_for_target(const Config & config, const std::string & target_name)
       filtered_config.connections.push_back(conn);
       try
       {
-        const auto & conn_node = config.nodes.at(*conn_to_add);
         if (!filtered_config.nodes.contains(*conn_to_add))
         {
           filtered_config.nodes.insert({*conn_to_add, config.nodes.at(*conn_to_add)});

--- a/cpp/src/node_builder/generator.cpp
+++ b/cpp/src/node_builder/generator.cpp
@@ -22,14 +22,160 @@
 
 #include "protoncpp/node_builder/generator.hpp"
 
+#include <algorithm>
+#include <optional>
+#include <vector>
+
 namespace proton::node_builder
 {
 
+struct ProducerConsumerIds
+{
+  std::map<uint32_t, std::vector<uint32_t>> producer_ids;
+  std::map<uint32_t, std::vector<uint32_t>> consumer_ids;
+};
+
+ProducerConsumerIds set_producer_consumer_ids(const Config & config)
+{
+  ProducerConsumerIds bundle_ids;
+  std::map<std::string, uint32_t> node_id_map{};
+  for (const auto & [name, node] : config.nodes)
+  {
+    node_id_map[name] = node.id;
+  }
+
+  const auto assign_id_by_name =
+    [&node_id_map](const std::vector<std::string> & prod_con_names, std::vector<uint32_t> & id_list)
+  {
+    for (const auto & name : prod_con_names)
+    {
+      if (node_id_map.contains(name))
+      {
+        id_list.push_back(node_id_map[name]);
+      }
+      else
+      {
+        throw NodeBuilderException(std::format("Error: {} is not a node name", name));
+      }
+    }
+  };
+
+  for (const auto & bundle : config.bundles)
+  {
+    assign_id_by_name(bundle.producers, bundle_ids.producer_ids[bundle.id]);
+    assign_id_by_name(bundle.consumers, bundle_ids.consumer_ids[bundle.id]);
+  }
+
+  return bundle_ids;
+}
+
+void validate(const Config & config)
+{
+  std::vector<uint32_t> signal_ids;
+  std::vector<std::string> signal_names;
+  for (const auto & signal : config.signals)
+  {
+    signal_ids.push_back(signal.id);
+    signal_names.push_back(signal.name);
+  }
+
+  std::vector<uint32_t> bundle_ids;
+  std::vector<std::string> bundle_names;
+  for (const auto & bundle : config.bundles)
+  {
+    bundle_ids.push_back(bundle.id);
+    bundle_names.push_back(bundle.name);
+  }
+
+  std::vector<uint32_t> node_ids;
+  std::vector<std::string> node_names;
+  for (const auto & [name, node] : config.nodes)
+  {
+    node_names.push_back(name);
+    node_ids.push_back(node.id);
+  }
+
+  find_duplicates<uint32_t>(signal_ids, "signal ID");
+  find_duplicates<std::string>(signal_names, "signal names");
+  find_duplicates<uint32_t>(bundle_ids, "bundle ID");
+  find_duplicates<std::string>(bundle_names, "bundle names");
+  find_duplicates<uint32_t>(node_ids, "nodes ID");
+  find_duplicates<std::string>(node_names, "node names");
+}
+
 Config filter_for_target(const Config & config, const std::string & target_name)
 {
-  Config config();
+  validate(config);
 
-  return config;
+  if (!config.nodes.contains(target_name))
+  {
+    throw NodeBuilderException(std::format("{} is not an available target node", target_name));
+  }
+
+  Config filtered_config = Config();
+
+  filtered_config.nodes.insert({target_name, config.nodes.at(target_name)});
+
+  for (const auto & conn : config.connections)
+  {
+    std::optional<std::string> conn_to_add = std::nullopt;
+    if (conn.first.node == target_name)
+    {
+      conn_to_add = conn.second.node;
+    }
+    else if (conn.second.node == target_name)
+    {
+      conn_to_add = conn.first.node;
+    }
+
+    if (conn_to_add.has_value())
+    {
+      filtered_config.connections.push_back(conn);
+      try
+      {
+        const auto & conn_node = config.nodes.at(*conn_to_add);
+        if (!filtered_config.nodes.contains(*conn_to_add))
+        {
+          filtered_config.nodes.insert({*conn_to_add, config.nodes.at(*conn_to_add)});
+        }
+      }
+      catch (const std::exception & e)
+      {
+        throw NodeBuilderException(std::format("Could not filter connection: {}", e.what()));
+      }
+    }
+  }
+
+  std::unordered_set<uint32_t> filtered_signal_ids;
+
+  for (const auto & bundle : config.bundles)
+  {
+    bool target_in_prods =
+      std::find(bundle.producers.begin(), bundle.producers.end(), target_name) !=
+      bundle.producers.end();
+    bool target_in_cons =
+      std::find(bundle.consumers.begin(), bundle.consumers.end(), target_name) !=
+      bundle.consumers.end();
+    if (target_in_prods || target_in_cons)
+    {
+      filtered_config.bundles.push_back(bundle);
+
+      for (const auto & signal_id : bundle.signals)
+      {
+        filtered_signal_ids.insert(signal_id);
+      }
+    }
+  }
+
+  for (const auto & signal : config.signals)
+  {
+    if (filtered_signal_ids.contains(signal.id))
+    {
+      filtered_config.signals.push_back(signal);
+    }
+  }
+
+  return filtered_config;
 }
 
 }  // namespace proton::node_builder

--- a/cpp/src/node_builder/generator.cpp
+++ b/cpp/src/node_builder/generator.cpp
@@ -227,12 +227,8 @@ void GeneratedNode::generate_endpoints(const Config & config, const std::string 
 void GeneratedNode::generate_signals(const Config & config)
 {
   signal_registry_.reserve(config.signals.size());
-  signal_id_lut_.reserve(config.signals.size());
-  signal_max_capacity_.reserve(config.signals.size());
   signal_decode_buffer_storage_.reserve(config.signals.size());
-  signal_decode_buffers_.reserve(config.signals.size());
-
-  size_t max_scratch_size = 0;
+  signal_scratch_buffer_.reserve(PROTON_SCRATCH_BUFFER_SIZE);
 
   for (size_t idx = 0; idx < config.signals.size(); idx++)
   {
@@ -243,14 +239,16 @@ void GeneratedNode::generate_signals(const Config & config)
       throw NodeBuilderException(std::format("Signal type is invalid: {}", signal_cfg.type_string));
     }
 
-    size_t value_size = get_signal_value_size(sig_type, signal_cfg.capacity);
+    uint16_t value_size = get_signal_value_size(sig_type, signal_cfg.capacity);
 
     // Create signal descriptor
     signal_desc_t sig_desc = {
       .id = signal_cfg.id,
       .type = sig_type,
       .value_size = value_size,
-      .signal = proton_Signal_init_zero};
+      .signal = proton_Signal_init_zero,
+      .signal_decode_buffer = nullptr,
+    };
 
     sig_desc.signal.which_signal = proton_get_tag_from_type(sig_type);
 
@@ -292,35 +290,16 @@ void GeneratedNode::generate_signals(const Config & config)
 
     signal_registry_.push_back(sig_desc);
 
-    // Create ID to index lookup entry
-    id_to_index_t lut_entry = {.id = signal_cfg.id, .idx = static_cast<uint32_t>(idx)};
-    signal_id_lut_.push_back(lut_entry);
-
-    // Track capacity for string/bytes types
-    signal_max_capacity_.push_back(signal_cfg.capacity);
-
     // Allocate decode buffer for string/bytes signals
     if (sig_type == PROTON_STRING || sig_type == PROTON_BYTES)
     {
       signal_decode_buffer_storage_.emplace_back(signal_cfg.capacity, 0);
-      max_scratch_size = std::max(max_scratch_size, static_cast<size_t>(signal_cfg.capacity));
+      sig_desc.signal_decode_buffer = signal_decode_buffer_storage_.back().data();
     }
     else
     {
       signal_decode_buffer_storage_.emplace_back();  // Empty vector for non-string/bytes
     }
-  }
-
-  // Build pointer array for decode buffers
-  for (auto & buf : signal_decode_buffer_storage_)
-  {
-    signal_decode_buffers_.push_back(buf.empty() ? nullptr : buf.data());
-  }
-
-  // Allocate scratch buffer (largest string/bytes capacity)
-  if (max_scratch_size > 0)
-  {
-    signal_scratch_buffer_.resize(max_scratch_size, 0);
   }
 }
 
@@ -331,13 +310,16 @@ void GeneratedNode::generate_bundles(const Config & config)
   bundle_consumer_ids_ = std::move(prod_con_ids.consumer_ids);
 
   bundle_table_.reserve(config.bundles.size());
-  bundle_id_lut_.reserve(config.bundles.size());
-  bundle_callbacks_.reserve(config.bundles.size());
-  bundle_encode_decode_buffers_.reserve(config.bundles.size());
+  size_t max_signal_count = 0;
 
   for (size_t idx = 0; idx < config.bundles.size(); idx++)
   {
     const auto & bundle_cfg = config.bundles[idx];
+
+    if (max_signal_count < bundle_cfg.signals.size())
+    {
+      max_signal_count = bundle_cfg.signals.size();
+    }
 
     // Store signal IDs for this bundle
     bundle_signal_ids_[bundle_cfg.id] = bundle_cfg.signals;
@@ -348,59 +330,43 @@ void GeneratedNode::generate_bundles(const Config & config)
       .producer_ids =
         {
           .ids = bundle_producer_ids_[bundle_cfg.id].data(),
-          .count = bundle_producer_ids_[bundle_cfg.id].size(),
+          .count = static_cast<uint8_t>(bundle_producer_ids_[bundle_cfg.id].size()),
         },
       .consumer_ids =
         {
           .ids = bundle_consumer_ids_[bundle_cfg.id].data(),
-          .count = bundle_consumer_ids_[bundle_cfg.id].size(),
+          .count = static_cast<uint8_t>(bundle_consumer_ids_[bundle_cfg.id].size()),
         },
       .signal_ids =
         {
           .ids = bundle_signal_ids_[bundle_cfg.id].data(),
-          .count = bundle_signal_ids_[bundle_cfg.id].size(),
+          .count = static_cast<uint8_t>(bundle_signal_ids_[bundle_cfg.id].size()),
         },
       .last_send_ms = 0,
       .period_ms = bundle_cfg.period_ms,
-      .send_now = false};
+      .send_now = false,
+      .callback =
+        {
+          .cb = nullptr,
+          .arg = nullptr,
+        },
+    };
     bundle_table_.push_back(bundle_desc);
-
-    // Create ID to index lookup entry
-    id_to_index_t lut_entry = {.id = bundle_cfg.id, .idx = static_cast<uint32_t>(idx)};
-    bundle_id_lut_.push_back(lut_entry);
-
-    // Create empty callback entry
-    proton_bundle_cb_t cb = {.cb = nullptr, .arg = nullptr};
-    bundle_callbacks_.push_back(cb);
-
-    // Allocate encode/decode buffer for signals in this bundle
-    std::vector<proton_Signal> encode_decode_signals(
-      bundle_cfg.signals.size(), proton_Signal_init_zero);
-    bundle_encode_decode_buffers_.push_back(std::move(encode_decode_signals));
   }
 
-  // Build pointer array for bundle signal pointers
-  bundle_signal_ptrs_.reserve(bundle_encode_decode_buffers_.size());
-  for (auto & buf : bundle_encode_decode_buffers_)
-  {
-    bundle_signal_ptrs_.push_back(buf.data());
-  }
+  // Build space for encode/decode buffer (largest bundle signal count)
+  bundle_encode_decode_buffer_.reserve(max_signal_count);
 }
 
 void GeneratedNode::init_registry()
 {
   // Bundle table and lookups
   registry_.bundle_table = bundle_table_.data();
-  registry_.bundle_id_lut = bundle_id_lut_.data();
-  registry_.bundle_callbacks = bundle_callbacks_.data();
   registry_.bundle_count = bundle_table_.size();
-  registry_.bundle_signal_ptrs = bundle_signal_ptrs_.data();
 
   // Signal table and lookups
   registry_.signal_registry = signal_registry_.data();
-  registry_.signal_id_lut = signal_id_lut_.data();
-  registry_.signal_max_capacity = signal_max_capacity_.data();
-  registry_.signal_decode_buffers = signal_decode_buffers_.data();
+  registry_.encode_decode_buffer = bundle_encode_decode_buffer_.data();
   registry_.signal_count = signal_registry_.size();
 
   // Scratch buffer for string/bytes encoding/decoding

--- a/cpp/src/node_builder/generator.cpp
+++ b/cpp/src/node_builder/generator.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Rockwell Automation Technologies, Inc., All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Tom Wallis (thomas.wallis@rockwellautomation.com)
+ */
+
+#include "proton/proton_config.h"
+
+#if PROTON_NODE_BUILDER
+
+#include "protoncpp/node_builder/generator.hpp"
+
+namespace proton::node_builder
+{
+
+Config filter_for_target(const Config & config, const std::string & target_name)
+{
+  Config config();
+
+  return config;
+}
+
+}  // namespace proton::node_builder
+
+#endif  // PROTON_NODE_BUILDER

--- a/cpp/tests/node_builder_generator_round_trip_test.cpp
+++ b/cpp/tests/node_builder_generator_round_trip_test.cpp
@@ -1,0 +1,661 @@
+/*
+ * Copyright 2026 Rockwell Automation Technologies, Inc., All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Tom Wallis (thomas.wallis@rockwellautomation.com)
+ */
+
+#include <gtest/gtest.h>
+#include <cstring>
+#include <limits>
+#include <string>
+
+#include "proton/encode_decode.h"
+#include "proton/registry.h"
+#include "protoncpp/node_builder/generator.hpp"
+
+using namespace proton::node_builder;
+
+static constexpr size_t BUFFER_SIZE = 1024;
+
+// Signal IDs used in tests
+static constexpr uint32_t SIG_DOUBLE_ID = 100;
+static constexpr uint32_t SIG_FLOAT_ID = 101;
+static constexpr uint32_t SIG_INT32_ID = 102;
+static constexpr uint32_t SIG_INT64_ID = 103;
+static constexpr uint32_t SIG_UINT32_ID = 104;
+static constexpr uint32_t SIG_UINT64_ID = 105;
+static constexpr uint32_t SIG_BOOL_ID = 106;
+static constexpr uint32_t SIG_STRING_ID = 107;
+static constexpr uint32_t SIG_BYTES_ID = 108;
+
+static constexpr uint32_t BUNDLE_ALL_TYPES_ID = 10;
+static constexpr uint32_t BUNDLE_NUMERIC_ID = 11;
+static constexpr uint32_t BUNDLE_STRING_BYTES_ID = 12;
+
+static constexpr size_t STRING_CAPACITY = 64;
+static constexpr size_t BYTES_CAPACITY = 32;
+
+// Helper to create a config with all signal types for round-trip testing
+Config create_round_trip_config()
+{
+  Config config;
+
+  // Add two nodes
+  NodeConfig node_a;
+  node_a.name = "node_a";
+  node_a.id = 1;
+  node_a.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.1", 5000};
+
+  NodeConfig node_b;
+  node_b.name = "node_b";
+  node_b.id = 2;
+  node_b.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.2", 5000};
+
+  config.nodes["node_a"] = node_a;
+  config.nodes["node_b"] = node_b;
+
+  // Add connection
+  ConnectionConfig conn_ab;
+  conn_ab.first = {0, "node_a"};
+  conn_ab.second = {0, "node_b"};
+  config.connections.push_back(conn_ab);
+
+  // Add signals of all types
+  config.signals.push_back(SignalConfig("double_signal", SIG_DOUBLE_ID, "double"));
+  config.signals.push_back(SignalConfig("float_signal", SIG_FLOAT_ID, "float"));
+  config.signals.push_back(SignalConfig("int32_signal", SIG_INT32_ID, "int32"));
+  config.signals.push_back(SignalConfig("int64_signal", SIG_INT64_ID, "int64"));
+  config.signals.push_back(SignalConfig("uint32_signal", SIG_UINT32_ID, "uint32"));
+  config.signals.push_back(SignalConfig("uint64_signal", SIG_UINT64_ID, "uint64"));
+  config.signals.push_back(SignalConfig("bool_signal", SIG_BOOL_ID, "bool"));
+  config.signals.push_back(SignalConfig("string_signal", SIG_STRING_ID, "string", STRING_CAPACITY));
+  config.signals.push_back(SignalConfig("bytes_signal", SIG_BYTES_ID, "bytes", BYTES_CAPACITY));
+
+  // Bundle with all signal types
+  BundleConfig bundle_all;
+  bundle_all.name = "bundle_all_types";
+  bundle_all.id = BUNDLE_ALL_TYPES_ID;
+  bundle_all.period_ms = 100;
+  bundle_all.producers = {"node_a"};
+  bundle_all.consumers = {"node_b"};
+  bundle_all.signals = {SIG_DOUBLE_ID, SIG_FLOAT_ID, SIG_INT32_ID,  SIG_INT64_ID, SIG_UINT32_ID,
+                        SIG_UINT64_ID, SIG_BOOL_ID,  SIG_STRING_ID, SIG_BYTES_ID};
+  config.bundles.push_back(bundle_all);
+
+  // Bundle with only numeric types
+  BundleConfig bundle_numeric;
+  bundle_numeric.name = "bundle_numeric";
+  bundle_numeric.id = BUNDLE_NUMERIC_ID;
+  bundle_numeric.period_ms = 50;
+  bundle_numeric.producers = {"node_a"};
+  bundle_numeric.consumers = {"node_b"};
+  bundle_numeric.signals = {SIG_DOUBLE_ID, SIG_FLOAT_ID,  SIG_INT32_ID,
+                            SIG_INT64_ID,  SIG_UINT32_ID, SIG_UINT64_ID};
+  config.bundles.push_back(bundle_numeric);
+
+  // Bundle with string and bytes only
+  BundleConfig bundle_string_bytes;
+  bundle_string_bytes.name = "bundle_string_bytes";
+  bundle_string_bytes.id = BUNDLE_STRING_BYTES_ID;
+  bundle_string_bytes.period_ms = 200;
+  bundle_string_bytes.producers = {"node_a"};
+  bundle_string_bytes.consumers = {"node_b"};
+  bundle_string_bytes.signals = {SIG_STRING_ID, SIG_BYTES_ID};
+  config.bundles.push_back(bundle_string_bytes);
+
+  return config;
+}
+
+// ============================================================================
+// GeneratedNode Round-Trip Tests
+// ============================================================================
+
+class GeneratedNodeRoundTripTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    config_ = create_round_trip_config();
+    generated_node_ = std::make_unique<GeneratedNode>(config_, "node_a");
+  }
+
+  void TearDown() override { generated_node_.reset(); }
+
+  Config config_;
+  std::unique_ptr<GeneratedNode> generated_node_;
+};
+
+TEST_F(GeneratedNodeRoundTripTest, NodeAndRegistryAccessorsReturnValidPointers)
+{
+  ASSERT_NE(generated_node_->node(), nullptr);
+  ASSERT_NE(generated_node_->registry(), nullptr);
+  EXPECT_EQ(generated_node_->node()->id, 1);
+  EXPECT_EQ(generated_node_->node()->registry, generated_node_->registry());
+}
+
+TEST_F(GeneratedNodeRoundTripTest, RegistryContainsExpectedSignals)
+{
+  proton_registry_t * registry = generated_node_->registry();
+
+  // Verify all signals are present
+  EXPECT_NE(proton_registry_get_signal(registry, SIG_DOUBLE_ID, nullptr), nullptr);
+  EXPECT_NE(proton_registry_get_signal(registry, SIG_FLOAT_ID, nullptr), nullptr);
+  EXPECT_NE(proton_registry_get_signal(registry, SIG_INT32_ID, nullptr), nullptr);
+  EXPECT_NE(proton_registry_get_signal(registry, SIG_INT64_ID, nullptr), nullptr);
+  EXPECT_NE(proton_registry_get_signal(registry, SIG_UINT32_ID, nullptr), nullptr);
+  EXPECT_NE(proton_registry_get_signal(registry, SIG_UINT64_ID, nullptr), nullptr);
+  EXPECT_NE(proton_registry_get_signal(registry, SIG_BOOL_ID, nullptr), nullptr);
+  EXPECT_NE(proton_registry_get_signal(registry, SIG_STRING_ID, nullptr), nullptr);
+  EXPECT_NE(proton_registry_get_signal(registry, SIG_BYTES_ID, nullptr), nullptr);
+}
+
+TEST_F(GeneratedNodeRoundTripTest, RegistryContainsExpectedBundles)
+{
+  proton_registry_t * registry = generated_node_->registry();
+
+  EXPECT_NE(proton_registry_get_bundle(registry, BUNDLE_ALL_TYPES_ID, nullptr), nullptr);
+  EXPECT_NE(proton_registry_get_bundle(registry, BUNDLE_NUMERIC_ID, nullptr), nullptr);
+  EXPECT_NE(proton_registry_get_bundle(registry, BUNDLE_STRING_BYTES_ID, nullptr), nullptr);
+}
+
+TEST_F(GeneratedNodeRoundTripTest, RoundTripDouble)
+{
+  proton_registry_t * registry = generated_node_->registry();
+  uint8_t buffer[BUFFER_SIZE];
+  size_t bytes_encoded = 0;
+
+  const double test_value = 3.14159265358979;
+  ASSERT_EQ(proton_signal_set_double(registry, SIG_DOUBLE_ID, test_value), PROTON_OK);
+
+  ASSERT_EQ(
+    proton_encode_bundle(registry, BUNDLE_NUMERIC_ID, buffer, sizeof(buffer), &bytes_encoded),
+    PROTON_OK);
+  ASSERT_GT(bytes_encoded, 0u);
+
+  // Zero out the signal before decode
+  ASSERT_EQ(proton_signal_set_double(registry, SIG_DOUBLE_ID, 0.0), PROTON_OK);
+
+  proton_Proton decoded_msg = proton_Proton_init_zero;
+  ASSERT_EQ(proton_decode(registry, buffer, bytes_encoded, &decoded_msg), PROTON_OK);
+
+  double decoded_value = 0.0;
+  ASSERT_EQ(proton_signal_get_double(registry, SIG_DOUBLE_ID, &decoded_value), PROTON_OK);
+  EXPECT_DOUBLE_EQ(decoded_value, test_value);
+}
+
+TEST_F(GeneratedNodeRoundTripTest, RoundTripFloat)
+{
+  proton_registry_t * registry = generated_node_->registry();
+  uint8_t buffer[BUFFER_SIZE];
+  size_t bytes_encoded = 0;
+
+  const float test_value = 2.71828f;
+  ASSERT_EQ(proton_signal_set_float(registry, SIG_FLOAT_ID, test_value), PROTON_OK);
+
+  ASSERT_EQ(
+    proton_encode_bundle(registry, BUNDLE_NUMERIC_ID, buffer, sizeof(buffer), &bytes_encoded),
+    PROTON_OK);
+  ASSERT_GT(bytes_encoded, 0u);
+
+  ASSERT_EQ(proton_signal_set_float(registry, SIG_FLOAT_ID, 0.0f), PROTON_OK);
+
+  proton_Proton decoded_msg = proton_Proton_init_zero;
+  ASSERT_EQ(proton_decode(registry, buffer, bytes_encoded, &decoded_msg), PROTON_OK);
+
+  float decoded_value = 0.0f;
+  ASSERT_EQ(proton_signal_get_float(registry, SIG_FLOAT_ID, &decoded_value), PROTON_OK);
+  EXPECT_FLOAT_EQ(decoded_value, test_value);
+}
+
+TEST_F(GeneratedNodeRoundTripTest, RoundTripInt32)
+{
+  proton_registry_t * registry = generated_node_->registry();
+  uint8_t buffer[BUFFER_SIZE];
+  size_t bytes_encoded = 0;
+
+  const int32_t test_value = -2147483647;
+  ASSERT_EQ(proton_signal_set_int32(registry, SIG_INT32_ID, test_value), PROTON_OK);
+
+  ASSERT_EQ(
+    proton_encode_bundle(registry, BUNDLE_NUMERIC_ID, buffer, sizeof(buffer), &bytes_encoded),
+    PROTON_OK);
+  ASSERT_GT(bytes_encoded, 0u);
+
+  ASSERT_EQ(proton_signal_set_int32(registry, SIG_INT32_ID, 0), PROTON_OK);
+
+  proton_Proton decoded_msg = proton_Proton_init_zero;
+  ASSERT_EQ(proton_decode(registry, buffer, bytes_encoded, &decoded_msg), PROTON_OK);
+
+  int32_t decoded_value = 0;
+  ASSERT_EQ(proton_signal_get_int32(registry, SIG_INT32_ID, &decoded_value), PROTON_OK);
+  EXPECT_EQ(decoded_value, test_value);
+}
+
+TEST_F(GeneratedNodeRoundTripTest, RoundTripInt64)
+{
+  proton_registry_t * registry = generated_node_->registry();
+  uint8_t buffer[BUFFER_SIZE];
+  size_t bytes_encoded = 0;
+
+  const int64_t test_value = -9223372036854775807LL;
+  ASSERT_EQ(proton_signal_set_int64(registry, SIG_INT64_ID, test_value), PROTON_OK);
+
+  ASSERT_EQ(
+    proton_encode_bundle(registry, BUNDLE_NUMERIC_ID, buffer, sizeof(buffer), &bytes_encoded),
+    PROTON_OK);
+  ASSERT_GT(bytes_encoded, 0u);
+
+  ASSERT_EQ(proton_signal_set_int64(registry, SIG_INT64_ID, 0), PROTON_OK);
+
+  proton_Proton decoded_msg = proton_Proton_init_zero;
+  ASSERT_EQ(proton_decode(registry, buffer, bytes_encoded, &decoded_msg), PROTON_OK);
+
+  int64_t decoded_value = 0;
+  ASSERT_EQ(proton_signal_get_int64(registry, SIG_INT64_ID, &decoded_value), PROTON_OK);
+  EXPECT_EQ(decoded_value, test_value);
+}
+
+TEST_F(GeneratedNodeRoundTripTest, RoundTripUint32)
+{
+  proton_registry_t * registry = generated_node_->registry();
+  uint8_t buffer[BUFFER_SIZE];
+  size_t bytes_encoded = 0;
+
+  const uint32_t test_value = 0xDEADBEEF;
+  ASSERT_EQ(proton_signal_set_uint32(registry, SIG_UINT32_ID, test_value), PROTON_OK);
+
+  ASSERT_EQ(
+    proton_encode_bundle(registry, BUNDLE_NUMERIC_ID, buffer, sizeof(buffer), &bytes_encoded),
+    PROTON_OK);
+  ASSERT_GT(bytes_encoded, 0u);
+
+  ASSERT_EQ(proton_signal_set_uint32(registry, SIG_UINT32_ID, 0), PROTON_OK);
+
+  proton_Proton decoded_msg = proton_Proton_init_zero;
+  ASSERT_EQ(proton_decode(registry, buffer, bytes_encoded, &decoded_msg), PROTON_OK);
+
+  uint32_t decoded_value = 0;
+  ASSERT_EQ(proton_signal_get_uint32(registry, SIG_UINT32_ID, &decoded_value), PROTON_OK);
+  EXPECT_EQ(decoded_value, test_value);
+}
+
+TEST_F(GeneratedNodeRoundTripTest, RoundTripUint64)
+{
+  proton_registry_t * registry = generated_node_->registry();
+  uint8_t buffer[BUFFER_SIZE];
+  size_t bytes_encoded = 0;
+
+  const uint64_t test_value = 0xDEADBEEFCAFEBABEULL;
+  ASSERT_EQ(proton_signal_set_uint64(registry, SIG_UINT64_ID, test_value), PROTON_OK);
+
+  ASSERT_EQ(
+    proton_encode_bundle(registry, BUNDLE_NUMERIC_ID, buffer, sizeof(buffer), &bytes_encoded),
+    PROTON_OK);
+  ASSERT_GT(bytes_encoded, 0u);
+
+  ASSERT_EQ(proton_signal_set_uint64(registry, SIG_UINT64_ID, 0), PROTON_OK);
+
+  proton_Proton decoded_msg = proton_Proton_init_zero;
+  ASSERT_EQ(proton_decode(registry, buffer, bytes_encoded, &decoded_msg), PROTON_OK);
+
+  uint64_t decoded_value = 0;
+  ASSERT_EQ(proton_signal_get_uint64(registry, SIG_UINT64_ID, &decoded_value), PROTON_OK);
+  EXPECT_EQ(decoded_value, test_value);
+}
+
+TEST_F(GeneratedNodeRoundTripTest, RoundTripBool)
+{
+  proton_registry_t * registry = generated_node_->registry();
+  uint8_t buffer[BUFFER_SIZE];
+  size_t bytes_encoded = 0;
+
+  // Test with true
+  ASSERT_EQ(proton_signal_set_bool(registry, SIG_BOOL_ID, true), PROTON_OK);
+
+  ASSERT_EQ(
+    proton_encode_bundle(registry, BUNDLE_ALL_TYPES_ID, buffer, sizeof(buffer), &bytes_encoded),
+    PROTON_OK);
+  ASSERT_GT(bytes_encoded, 0u);
+
+  ASSERT_EQ(proton_signal_set_bool(registry, SIG_BOOL_ID, false), PROTON_OK);
+
+  proton_Proton decoded_msg = proton_Proton_init_zero;
+  ASSERT_EQ(proton_decode(registry, buffer, bytes_encoded, &decoded_msg), PROTON_OK);
+
+  bool decoded_value = false;
+  ASSERT_EQ(proton_signal_get_bool(registry, SIG_BOOL_ID, &decoded_value), PROTON_OK);
+  EXPECT_TRUE(decoded_value);
+
+  // Test with false
+  ASSERT_EQ(proton_signal_set_bool(registry, SIG_BOOL_ID, false), PROTON_OK);
+
+  ASSERT_EQ(
+    proton_encode_bundle(registry, BUNDLE_ALL_TYPES_ID, buffer, sizeof(buffer), &bytes_encoded),
+    PROTON_OK);
+
+  ASSERT_EQ(proton_signal_set_bool(registry, SIG_BOOL_ID, true), PROTON_OK);
+
+  decoded_msg = proton_Proton_init_zero;
+  ASSERT_EQ(proton_decode(registry, buffer, bytes_encoded, &decoded_msg), PROTON_OK);
+
+  ASSERT_EQ(proton_signal_get_bool(registry, SIG_BOOL_ID, &decoded_value), PROTON_OK);
+  EXPECT_FALSE(decoded_value);
+}
+
+TEST_F(GeneratedNodeRoundTripTest, RoundTripString)
+{
+  proton_registry_t * registry = generated_node_->registry();
+  uint8_t buffer[BUFFER_SIZE];
+  size_t bytes_encoded = 0;
+
+  const char * test_value = "Hello, Proton!";
+  ASSERT_EQ(
+    proton_signal_set_string(registry, SIG_STRING_ID, test_value, strlen(test_value) + 1),
+    PROTON_OK);
+
+  ASSERT_EQ(
+    proton_encode_bundle(registry, BUNDLE_STRING_BYTES_ID, buffer, sizeof(buffer), &bytes_encoded),
+    PROTON_OK);
+  ASSERT_GT(bytes_encoded, 0u);
+
+  // Clear the string signal
+  // TODO this breaks the test later on
+  ASSERT_EQ(proton_signal_set_string(registry, SIG_STRING_ID, "", 1), PROTON_OK);
+
+  proton_Proton decoded_msg = proton_Proton_init_zero;
+  ASSERT_EQ(proton_decode(registry, buffer, bytes_encoded, &decoded_msg), PROTON_OK);
+
+  char decoded_string[STRING_CAPACITY] = {0};
+  size_t decoded_len = 0;
+  ASSERT_EQ(
+    proton_signal_get_string(
+      registry, SIG_STRING_ID, decoded_string, sizeof(decoded_string), &decoded_len),
+    PROTON_OK);
+  EXPECT_STREQ(decoded_string, test_value);
+}
+
+TEST_F(GeneratedNodeRoundTripTest, RoundTripBytes)
+{
+  proton_registry_t * registry = generated_node_->registry();
+  uint8_t buffer[BUFFER_SIZE];
+  size_t bytes_encoded = 0;
+
+  const uint8_t test_value[] = {0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE};
+  ASSERT_EQ(
+    proton_signal_set_bytes(registry, SIG_BYTES_ID, test_value, sizeof(test_value)), PROTON_OK);
+
+  ASSERT_EQ(
+    proton_encode_bundle(registry, BUNDLE_STRING_BYTES_ID, buffer, sizeof(buffer), &bytes_encoded),
+    PROTON_OK);
+  ASSERT_GT(bytes_encoded, 0u);
+
+  // Clear the bytes signal
+  const uint8_t empty_bytes[] = {0};
+  ASSERT_EQ(proton_signal_set_bytes(registry, SIG_BYTES_ID, empty_bytes, 0), PROTON_OK);
+
+  proton_Proton decoded_msg = proton_Proton_init_zero;
+  ASSERT_EQ(proton_decode(registry, buffer, bytes_encoded, &decoded_msg), PROTON_OK);
+
+  uint8_t decoded_bytes[BYTES_CAPACITY] = {0};
+  size_t decoded_len = 0;
+  ASSERT_EQ(
+    proton_signal_get_bytes(
+      registry, SIG_BYTES_ID, decoded_bytes, sizeof(decoded_bytes), &decoded_len),
+    PROTON_OK);
+  EXPECT_EQ(decoded_len, sizeof(test_value));
+  EXPECT_EQ(memcmp(decoded_bytes, test_value, sizeof(test_value)), 0);
+}
+
+TEST_F(GeneratedNodeRoundTripTest, RoundTripAllTypesBundle)
+{
+  proton_registry_t * registry = generated_node_->registry();
+  uint8_t buffer[BUFFER_SIZE];
+  size_t bytes_encoded = 0;
+
+  // Set all signal values
+  const double double_val = 1.23456789;
+  const float float_val = 9.87654f;
+  const int32_t int32_val = -42;
+  const int64_t int64_val = -1234567890123LL;
+  const uint32_t uint32_val = 0xABCD1234;
+  const uint64_t uint64_val = 0x123456789ABCDEFULL;
+  const bool bool_val = true;
+  const char * string_val = "test_string";
+  const uint8_t bytes_val[] = {1, 2, 3, 4, 5};
+
+  ASSERT_EQ(proton_signal_set_double(registry, SIG_DOUBLE_ID, double_val), PROTON_OK);
+  ASSERT_EQ(proton_signal_set_float(registry, SIG_FLOAT_ID, float_val), PROTON_OK);
+  ASSERT_EQ(proton_signal_set_int32(registry, SIG_INT32_ID, int32_val), PROTON_OK);
+  ASSERT_EQ(proton_signal_set_int64(registry, SIG_INT64_ID, int64_val), PROTON_OK);
+  ASSERT_EQ(proton_signal_set_uint32(registry, SIG_UINT32_ID, uint32_val), PROTON_OK);
+  ASSERT_EQ(proton_signal_set_uint64(registry, SIG_UINT64_ID, uint64_val), PROTON_OK);
+  ASSERT_EQ(proton_signal_set_bool(registry, SIG_BOOL_ID, bool_val), PROTON_OK);
+  ASSERT_EQ(
+    proton_signal_set_string(registry, SIG_STRING_ID, string_val, strlen(string_val) + 1),
+    PROTON_OK);
+  ASSERT_EQ(
+    proton_signal_set_bytes(registry, SIG_BYTES_ID, bytes_val, sizeof(bytes_val)), PROTON_OK);
+
+  // Encode bundle with all types
+  ASSERT_EQ(
+    proton_encode_bundle(registry, BUNDLE_ALL_TYPES_ID, buffer, sizeof(buffer), &bytes_encoded),
+    PROTON_OK);
+  ASSERT_GT(bytes_encoded, 0u);
+
+  // Clear all signals
+  ASSERT_EQ(proton_signal_set_double(registry, SIG_DOUBLE_ID, 0.0), PROTON_OK);
+  ASSERT_EQ(proton_signal_set_float(registry, SIG_FLOAT_ID, 0.0f), PROTON_OK);
+  ASSERT_EQ(proton_signal_set_int32(registry, SIG_INT32_ID, 0), PROTON_OK);
+  ASSERT_EQ(proton_signal_set_int64(registry, SIG_INT64_ID, 0), PROTON_OK);
+  ASSERT_EQ(proton_signal_set_uint32(registry, SIG_UINT32_ID, 0), PROTON_OK);
+  ASSERT_EQ(proton_signal_set_uint64(registry, SIG_UINT64_ID, 0), PROTON_OK);
+  ASSERT_EQ(proton_signal_set_bool(registry, SIG_BOOL_ID, false), PROTON_OK);
+  ASSERT_EQ(proton_signal_set_string(registry, SIG_STRING_ID, "", 1), PROTON_OK);
+  const uint8_t empty_bytes[] = {0};
+  ASSERT_EQ(proton_signal_set_bytes(registry, SIG_BYTES_ID, empty_bytes, 0), PROTON_OK);
+
+  // Decode
+  proton_Proton decoded_msg = proton_Proton_init_zero;
+  ASSERT_EQ(proton_decode(registry, buffer, bytes_encoded, &decoded_msg), PROTON_OK);
+
+  // Verify all values
+  double decoded_double = 0.0;
+  ASSERT_EQ(proton_signal_get_double(registry, SIG_DOUBLE_ID, &decoded_double), PROTON_OK);
+  EXPECT_DOUBLE_EQ(decoded_double, double_val);
+
+  float decoded_float = 0.0f;
+  ASSERT_EQ(proton_signal_get_float(registry, SIG_FLOAT_ID, &decoded_float), PROTON_OK);
+  EXPECT_FLOAT_EQ(decoded_float, float_val);
+
+  int32_t decoded_int32 = 0;
+  ASSERT_EQ(proton_signal_get_int32(registry, SIG_INT32_ID, &decoded_int32), PROTON_OK);
+  EXPECT_EQ(decoded_int32, int32_val);
+
+  int64_t decoded_int64 = 0;
+  ASSERT_EQ(proton_signal_get_int64(registry, SIG_INT64_ID, &decoded_int64), PROTON_OK);
+  EXPECT_EQ(decoded_int64, int64_val);
+
+  uint32_t decoded_uint32 = 0;
+  ASSERT_EQ(proton_signal_get_uint32(registry, SIG_UINT32_ID, &decoded_uint32), PROTON_OK);
+  EXPECT_EQ(decoded_uint32, uint32_val);
+
+  uint64_t decoded_uint64 = 0;
+  ASSERT_EQ(proton_signal_get_uint64(registry, SIG_UINT64_ID, &decoded_uint64), PROTON_OK);
+  EXPECT_EQ(decoded_uint64, uint64_val);
+
+  bool decoded_bool = false;
+  ASSERT_EQ(proton_signal_get_bool(registry, SIG_BOOL_ID, &decoded_bool), PROTON_OK);
+  EXPECT_EQ(decoded_bool, bool_val);
+
+  char decoded_string[STRING_CAPACITY] = {0};
+  size_t string_len = 0;
+  ASSERT_EQ(
+    proton_signal_get_string(
+      registry, SIG_STRING_ID, decoded_string, sizeof(decoded_string), &string_len),
+    PROTON_OK);
+  EXPECT_STREQ(decoded_string, string_val);
+
+  uint8_t decoded_bytes[BYTES_CAPACITY] = {0};
+  size_t bytes_len = 0;
+  ASSERT_EQ(
+    proton_signal_get_bytes(
+      registry, SIG_BYTES_ID, decoded_bytes, sizeof(decoded_bytes), &bytes_len),
+    PROTON_OK);
+  EXPECT_EQ(bytes_len, sizeof(bytes_val));
+  EXPECT_EQ(memcmp(decoded_bytes, bytes_val, sizeof(bytes_val)), 0);
+}
+
+TEST_F(GeneratedNodeRoundTripTest, RoundTripBoundaryValues)
+{
+  proton_registry_t * registry = generated_node_->registry();
+  uint8_t buffer[BUFFER_SIZE];
+  size_t bytes_encoded = 0;
+
+  // Test boundary values for numeric types
+  ASSERT_EQ(
+    proton_signal_set_int32(registry, SIG_INT32_ID, std::numeric_limits<int32_t>::min()),
+    PROTON_OK);
+  ASSERT_EQ(
+    proton_signal_set_int64(registry, SIG_INT64_ID, std::numeric_limits<int64_t>::min()),
+    PROTON_OK);
+  ASSERT_EQ(
+    proton_signal_set_uint32(registry, SIG_UINT32_ID, std::numeric_limits<uint32_t>::max()),
+    PROTON_OK);
+  ASSERT_EQ(
+    proton_signal_set_uint64(registry, SIG_UINT64_ID, std::numeric_limits<uint64_t>::max()),
+    PROTON_OK);
+
+  ASSERT_EQ(
+    proton_encode_bundle(registry, BUNDLE_NUMERIC_ID, buffer, sizeof(buffer), &bytes_encoded),
+    PROTON_OK);
+
+  // Reset values
+  ASSERT_EQ(proton_signal_set_int32(registry, SIG_INT32_ID, 0), PROTON_OK);
+  ASSERT_EQ(proton_signal_set_int64(registry, SIG_INT64_ID, 0), PROTON_OK);
+  ASSERT_EQ(proton_signal_set_uint32(registry, SIG_UINT32_ID, 0), PROTON_OK);
+  ASSERT_EQ(proton_signal_set_uint64(registry, SIG_UINT64_ID, 0), PROTON_OK);
+
+  proton_Proton decoded_msg = proton_Proton_init_zero;
+  ASSERT_EQ(proton_decode(registry, buffer, bytes_encoded, &decoded_msg), PROTON_OK);
+
+  int32_t decoded_int32 = 0;
+  ASSERT_EQ(proton_signal_get_int32(registry, SIG_INT32_ID, &decoded_int32), PROTON_OK);
+  EXPECT_EQ(decoded_int32, std::numeric_limits<int32_t>::min());
+
+  int64_t decoded_int64 = 0;
+  ASSERT_EQ(proton_signal_get_int64(registry, SIG_INT64_ID, &decoded_int64), PROTON_OK);
+  EXPECT_EQ(decoded_int64, std::numeric_limits<int64_t>::min());
+
+  uint32_t decoded_uint32 = 0;
+  ASSERT_EQ(proton_signal_get_uint32(registry, SIG_UINT32_ID, &decoded_uint32), PROTON_OK);
+  EXPECT_EQ(decoded_uint32, std::numeric_limits<uint32_t>::max());
+
+  uint64_t decoded_uint64 = 0;
+  ASSERT_EQ(proton_signal_get_uint64(registry, SIG_UINT64_ID, &decoded_uint64), PROTON_OK);
+  EXPECT_EQ(decoded_uint64, std::numeric_limits<uint64_t>::max());
+}
+
+TEST_F(GeneratedNodeRoundTripTest, RoundTripMultipleEncodesDecodes)
+{
+  proton_registry_t * registry = generated_node_->registry();
+  uint8_t buffer1[BUFFER_SIZE];
+  uint8_t buffer2[BUFFER_SIZE];
+  size_t bytes_encoded1 = 0;
+  size_t bytes_encoded2 = 0;
+
+  // First encode with value 1
+  const int32_t value1 = 100;
+  ASSERT_EQ(proton_signal_set_int32(registry, SIG_INT32_ID, value1), PROTON_OK);
+  ASSERT_EQ(
+    proton_encode_bundle(registry, BUNDLE_NUMERIC_ID, buffer1, sizeof(buffer1), &bytes_encoded1),
+    PROTON_OK);
+
+  // Second encode with value 2
+  const int32_t value2 = 200;
+  ASSERT_EQ(proton_signal_set_int32(registry, SIG_INT32_ID, value2), PROTON_OK);
+  ASSERT_EQ(
+    proton_encode_bundle(registry, BUNDLE_NUMERIC_ID, buffer2, sizeof(buffer2), &bytes_encoded2),
+    PROTON_OK);
+
+  // Decode buffer1 - should restore value1
+  proton_Proton decoded_msg = proton_Proton_init_zero;
+  ASSERT_EQ(proton_decode(registry, buffer1, bytes_encoded1, &decoded_msg), PROTON_OK);
+
+  int32_t decoded_value = 0;
+  ASSERT_EQ(proton_signal_get_int32(registry, SIG_INT32_ID, &decoded_value), PROTON_OK);
+  EXPECT_EQ(decoded_value, value1);
+
+  // Decode buffer2 - should restore value2
+  decoded_msg = proton_Proton_init_zero;
+  ASSERT_EQ(proton_decode(registry, buffer2, bytes_encoded2, &decoded_msg), PROTON_OK);
+
+  ASSERT_EQ(proton_signal_get_int32(registry, SIG_INT32_ID, &decoded_value), PROTON_OK);
+  EXPECT_EQ(decoded_value, value2);
+}
+
+TEST_F(GeneratedNodeRoundTripTest, RoundTripEmptyString)
+{
+  proton_registry_t * registry = generated_node_->registry();
+  uint8_t buffer[BUFFER_SIZE];
+  size_t bytes_encoded = 0;
+
+  // Set empty string (just null terminator)
+  ASSERT_EQ(proton_signal_set_string(registry, SIG_STRING_ID, "", 1), PROTON_OK);
+
+  ASSERT_EQ(
+    proton_encode_bundle(registry, BUNDLE_STRING_BYTES_ID, buffer, sizeof(buffer), &bytes_encoded),
+    PROTON_OK);
+  ASSERT_GT(bytes_encoded, 0u);
+
+  // Set a non-empty value before decode
+  ASSERT_EQ(proton_signal_set_string(registry, SIG_STRING_ID, "not_empty", 10), PROTON_OK);
+
+  proton_Proton decoded_msg = proton_Proton_init_zero;
+  ASSERT_EQ(proton_decode(registry, buffer, bytes_encoded, &decoded_msg), PROTON_OK);
+
+  char decoded_string[STRING_CAPACITY] = {0};
+  size_t decoded_len = 0;
+  ASSERT_EQ(
+    proton_signal_get_string(
+      registry, SIG_STRING_ID, decoded_string, sizeof(decoded_string), &decoded_len),
+    PROTON_OK);
+  EXPECT_STREQ(decoded_string, "");
+}
+
+TEST_F(GeneratedNodeRoundTripTest, MoveConstructorPreservesState)
+{
+  proton_registry_t * registry = generated_node_->registry();
+
+  // Set a value
+  const double test_value = 42.0;
+  ASSERT_EQ(proton_signal_set_double(registry, SIG_DOUBLE_ID, test_value), PROTON_OK);
+
+  // Move the node
+  GeneratedNode moved_node = std::move(*generated_node_);
+
+  // Verify the moved node still has valid state
+  proton_registry_t * moved_registry = moved_node.registry();
+  ASSERT_NE(moved_registry, nullptr);
+
+  double decoded_value = 0.0;
+  ASSERT_EQ(proton_signal_get_double(moved_registry, SIG_DOUBLE_ID, &decoded_value), PROTON_OK);
+  EXPECT_DOUBLE_EQ(decoded_value, test_value);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/cpp/tests/node_builder_generator_round_trip_test.cpp
+++ b/cpp/tests/node_builder_generator_round_trip_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Rockwell Automation Technologies, Inc., All rights reserved.
+ * Copyright SIG_DEFAULT_BOOL_ID6 Rockwell Automation Technologies, Inc., All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,17 @@ static constexpr uint32_t BUNDLE_STRING_BYTES_ID = 12;
 
 static constexpr size_t STRING_CAPACITY = 64;
 static constexpr size_t BYTES_CAPACITY = 32;
+
+// Signal IDs used for signals with default values
+static constexpr uint32_t SIG_DEFAULT_DOUBLE_ID = 200;
+static constexpr uint32_t SIG_DEFAULT_FLOAT_ID = 201;
+static constexpr uint32_t SIG_DEFAULT_INT32_ID = 202;
+static constexpr uint32_t SIG_DEFAULT_INT64_ID = 203;
+static constexpr uint32_t SIG_DEFAULT_UINT32_ID = 204;
+static constexpr uint32_t SIG_DEFAULT_UINT64_ID = 205;
+static constexpr uint32_t SIG_DEFAULT_BOOL_ID = 206;
+static constexpr uint32_t SIG_DEFAULT_STRING_ID = 207;
+static constexpr uint32_t SIG_DEFAULT_BYTES_ID = 208;
 
 // Helper to create a config with all signal types for round-trip testing
 Config create_round_trip_config()
@@ -652,6 +663,582 @@ TEST_F(GeneratedNodeRoundTripTest, MoveConstructorPreservesState)
   double decoded_value = 0.0;
   ASSERT_EQ(proton_signal_get_double(moved_registry, SIG_DOUBLE_ID, &decoded_value), PROTON_OK);
   EXPECT_DOUBLE_EQ(decoded_value, test_value);
+}
+
+// ============================================================================
+// Default Value Tests
+// ============================================================================
+
+Config create_default_values_config()
+{
+  Config config;
+
+  NodeConfig node_a;
+  node_a.name = "node_a";
+  node_a.id = 1;
+  node_a.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.1", 5000};
+
+  NodeConfig node_b;
+  node_b.name = "node_b";
+  node_b.id = 2;
+  node_b.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.2", 5000};
+
+  config.nodes["node_a"] = node_a;
+  config.nodes["node_b"] = node_b;
+
+  ConnectionConfig conn_ab;
+  conn_ab.first = {0, "node_a"};
+  conn_ab.second = {0, "node_b"};
+  config.connections.push_back(conn_ab);
+
+  // Signal with default double value
+  SignalConfig sig_double("default_double", SIG_DEFAULT_DOUBLE_ID, "double");
+  sig_double.has_default_value = true;
+  sig_double.value = 3.14159;
+  config.signals.push_back(sig_double);
+
+  // Signal with default float value
+  SignalConfig sig_float("default_float", SIG_DEFAULT_FLOAT_ID, "float");
+  sig_float.has_default_value = true;
+  sig_float.value = 1.141;
+  config.signals.push_back(sig_float);
+
+  // Signal with default int32 value
+  SignalConfig sig_int32("default_int32", SIG_DEFAULT_INT32_ID, "int32");
+  sig_int32.has_default_value = true;
+  sig_int32.value = int32_t{-42};
+  config.signals.push_back(sig_int32);
+
+  // Signal with default int64 value
+  SignalConfig sig_int64("default_int64", SIG_DEFAULT_INT64_ID, "int64");
+  sig_int64.has_default_value = true;
+  sig_int64.value = int64_t{-64};
+  config.signals.push_back(sig_int64);
+
+  // Signal with default uint32 value
+  SignalConfig sig_uint32("default_uint32", SIG_DEFAULT_UINT32_ID, "uint32");
+  sig_uint32.has_default_value = true;
+  sig_uint32.value = uint32_t{42};
+  config.signals.push_back(sig_uint32);
+
+  // Signal with default bool value
+  SignalConfig sig_bool("default_bool", SIG_DEFAULT_BOOL_ID, "bool");
+  sig_bool.has_default_value = true;
+  sig_bool.value = true;
+  config.signals.push_back(sig_bool);
+
+  // Signal with default uint64 value
+  SignalConfig sig_uint64("default_uint64", SIG_DEFAULT_UINT64_ID, "uint64");
+  sig_uint64.has_default_value = true;
+  sig_uint64.value = uint64_t{0xDEADBEEFCAFEBABEULL};
+  config.signals.push_back(sig_uint64);
+
+  // Signal with default string value
+  SignalConfig sig_string("default_string", SIG_DEFAULT_STRING_ID, "string", 64);
+  sig_string.has_default_value = true;
+  sig_string.value = std::string("hello_default");
+  config.signals.push_back(sig_string);
+
+  // Signal with default bytes value
+  SignalConfig sig_bytes("default_bytes", SIG_DEFAULT_BYTES_ID, "bytes", 64);
+  sig_bytes.has_default_value = true;
+  sig_bytes.value = ConfigSequence{ConfigValue(0), ConfigValue(1), ConfigValue(2)};
+  config.signals.push_back(sig_bytes);
+
+  BundleConfig bundle;
+  bundle.name = "defaults_bundle";
+  bundle.id = 20;
+  bundle.period_ms = 100;
+  bundle.producers = {"node_a"};
+  bundle.consumers = {"node_b"};
+  bundle.signals = {
+    SIG_DEFAULT_DOUBLE_ID, SIG_DEFAULT_FLOAT_ID,  SIG_DEFAULT_INT32_ID,
+    SIG_DEFAULT_INT64_ID,  SIG_DEFAULT_UINT32_ID, SIG_DEFAULT_UINT64_ID,
+    SIG_DEFAULT_BOOL_ID,   SIG_DEFAULT_STRING_ID, SIG_DEFAULT_BYTES_ID,
+  };
+  config.bundles.push_back(bundle);
+
+  return config;
+}
+
+TEST(DefaultValuesTest, DoubleDefaultValue)
+{
+  Config config = create_default_values_config();
+  GeneratedNode node(config, "node_a");
+
+  double value = 0.0;
+  ASSERT_EQ(proton_signal_get_double(node.registry(), SIG_DEFAULT_DOUBLE_ID, &value), PROTON_OK);
+  EXPECT_DOUBLE_EQ(value, 3.14159);
+}
+
+TEST(DefaultValuesTest, FloatDefaultValue)
+{
+  Config config = create_default_values_config();
+  GeneratedNode node(config, "node_a");
+
+  float value = 0.0;
+  ASSERT_EQ(proton_signal_get_float(node.registry(), SIG_DEFAULT_FLOAT_ID, &value), PROTON_OK);
+  EXPECT_FLOAT_EQ(value, 1.141);
+}
+
+TEST(DefaultValuesTest, Int32DefaultValue)
+{
+  Config config = create_default_values_config();
+  GeneratedNode node(config, "node_a");
+
+  int32_t value = 0;
+  ASSERT_EQ(proton_signal_get_int32(node.registry(), SIG_DEFAULT_INT32_ID, &value), PROTON_OK);
+  EXPECT_EQ(value, -42);
+}
+
+TEST(DefaultValuesTest, Int64DefaultValue)
+{
+  Config config = create_default_values_config();
+  GeneratedNode node(config, "node_a");
+
+  int64_t value = 0;
+  ASSERT_EQ(proton_signal_get_int64(node.registry(), SIG_DEFAULT_INT64_ID, &value), PROTON_OK);
+  EXPECT_EQ(value, -64);
+}
+
+TEST(DefaultValuesTest, UInt32DefaultValue)
+{
+  Config config = create_default_values_config();
+  GeneratedNode node(config, "node_a");
+
+  uint32_t value = 0;
+  ASSERT_EQ(proton_signal_get_uint32(node.registry(), SIG_DEFAULT_UINT32_ID, &value), PROTON_OK);
+  EXPECT_EQ(value, 42);
+}
+
+TEST(DefaultValuesTest, BoolDefaultValue)
+{
+  Config config = create_default_values_config();
+  GeneratedNode node(config, "node_a");
+
+  bool value = false;
+  ASSERT_EQ(proton_signal_get_bool(node.registry(), SIG_DEFAULT_BOOL_ID, &value), PROTON_OK);
+  EXPECT_TRUE(value);
+}
+
+TEST(DefaultValuesTest, Uint64DefaultValue)
+{
+  Config config = create_default_values_config();
+  GeneratedNode node(config, "node_a");
+
+  uint64_t value = 0;
+  ASSERT_EQ(proton_signal_get_uint64(node.registry(), SIG_DEFAULT_UINT64_ID, &value), PROTON_OK);
+  EXPECT_EQ(value, 0xDEADBEEFCAFEBABEULL);
+}
+
+TEST(DefaultValuesTest, StringDefaultValue)
+{
+  Config config = create_default_values_config();
+  GeneratedNode node(config, "node_a");
+
+  char buf[64] = {0};
+  size_t len = 0;
+  ASSERT_EQ(
+    proton_signal_get_string(node.registry(), SIG_DEFAULT_STRING_ID, buf, sizeof(buf), &len),
+    PROTON_OK);
+  EXPECT_STREQ(buf, "hello_default");
+}
+
+TEST(DefaultValuesTest, BytesDefaultValue)
+{
+  Config config = create_default_values_config();
+  GeneratedNode node(config, "node_a");
+
+  uint8_t buf[64] = {0};
+  size_t len = 0;
+  ASSERT_EQ(
+    proton_signal_get_bytes(node.registry(), SIG_DEFAULT_BYTES_ID, buf, sizeof(buf), &len),
+    PROTON_OK);
+  EXPECT_EQ(len, 3);
+  EXPECT_EQ(buf[0], 0);
+  EXPECT_EQ(buf[1], 1);
+  EXPECT_EQ(buf[2], 2);
+}
+
+TEST(DefaultValuesTest, RoundTripPreservesDefaults)
+{
+  Config config = create_default_values_config();
+  GeneratedNode node(config, "node_a");
+
+  uint8_t buffer[BUFFER_SIZE];
+  size_t bytes_encoded = 0;
+
+  // Encode with default values
+  ASSERT_EQ(
+    proton_encode_bundle(node.registry(), 20, buffer, sizeof(buffer), &bytes_encoded), PROTON_OK);
+  ASSERT_GT(bytes_encoded, 0u);
+
+  // Create a second node to decode into
+  GeneratedNode node2(config, "node_a");
+
+  // Modify values before decode
+  ASSERT_EQ(proton_signal_set_double(node2.registry(), SIG_DEFAULT_DOUBLE_ID, 999.0), PROTON_OK);
+  ASSERT_EQ(proton_signal_set_int32(node2.registry(), SIG_DEFAULT_INT32_ID, 999), PROTON_OK);
+
+  proton_Proton decoded_msg = proton_Proton_init_zero;
+  ASSERT_EQ(proton_decode(node2.registry(), buffer, bytes_encoded, &decoded_msg), PROTON_OK);
+
+  // Verify decoded values match original defaults
+  double double_val = 0.0;
+  ASSERT_EQ(
+    proton_signal_get_double(node2.registry(), SIG_DEFAULT_DOUBLE_ID, &double_val), PROTON_OK);
+  EXPECT_DOUBLE_EQ(double_val, 3.14159);
+
+  int32_t int32_val = 0;
+  ASSERT_EQ(proton_signal_get_int32(node2.registry(), SIG_DEFAULT_INT32_ID, &int32_val), PROTON_OK);
+  EXPECT_EQ(int32_val, -42);
+}
+
+// ============================================================================
+// Invalid signal type Tests
+// ============================================================================
+
+TEST(InvalidSignalType, InvalidSignalTypeThrows)
+{
+  Config config;
+
+  NodeConfig node_a;
+  node_a.name = "node_a";
+  node_a.id = 1;
+  node_a.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB0", "", 0};
+
+  NodeConfig node_b;
+  node_b.name = "node_b";
+  node_b.id = 2;
+  node_b.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB1", "", 0};
+
+  config.nodes["node_a"] = node_a;
+  config.nodes["node_b"] = node_b;
+
+  ConnectionConfig conn;
+  conn.first = {0, "node_a"};
+  conn.second = {0, "node_b"};
+  config.connections.push_back(conn);
+
+  SignalConfig sig("test_signal", 100, "invalid_signal_type");
+  config.signals.push_back(sig);
+
+  BundleConfig bundle;
+  bundle.name = "test_bundle";
+  bundle.id = 10;
+  bundle.period_ms = 100;
+  bundle.producers = {"node_a"};
+  bundle.consumers = {"node_b"};
+  bundle.signals = {100};
+  config.bundles.push_back(bundle);
+
+  EXPECT_THROW(GeneratedNode(config, "node_a"), NodeBuilderException);
+}
+
+// ============================================================================
+// Invalid node name Tests
+// ============================================================================
+
+TEST(InvalidNodeName, InvalidNodeNameThrows)
+{
+  Config config;
+
+  NodeConfig node_a;
+  node_a.name = "node_a";
+  node_a.id = 1;
+  node_a.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB0", "", 0};
+
+  NodeConfig node_b;
+  node_b.name = "node_b";
+  node_b.id = 2;
+  node_b.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB1", "", 0};
+
+  config.nodes["node_a"] = node_a;
+  config.nodes["node_b"] = node_b;
+
+  ConnectionConfig conn;
+  conn.first = {0, "node_a"};
+  conn.second = {0, "node_b"};
+  config.connections.push_back(conn);
+
+  SignalConfig sig("test_signal", 100, "invalid_signal_type");
+  config.signals.push_back(sig);
+
+  BundleConfig bundle;
+  bundle.name = "test_bundle";
+  bundle.id = 10;
+  bundle.period_ms = 100;
+  bundle.producers = {"node_a"};
+  bundle.consumers = {"node_b"};
+  bundle.signals = {100};
+  config.bundles.push_back(bundle);
+
+  EXPECT_THROW(GeneratedNode(config, "node_notanode"), NodeBuilderException);
+}
+
+// ============================================================================
+// Invalid Transport Tests
+// ============================================================================
+
+TEST(InvalidTransportTest, InvalidTransportTypeThrows)
+{
+  Config config;
+
+  NodeConfig node_a;
+  node_a.name = "node_a";
+  node_a.id = 1;
+  node_a.endpoints[0] = EndpointConfig{0, "invalid_transport", "", "192.168.1.1", 5000};
+
+  NodeConfig node_b;
+  node_b.name = "node_b";
+  node_b.id = 2;
+  node_b.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.2", 5000};
+
+  config.nodes["node_a"] = node_a;
+  config.nodes["node_b"] = node_b;
+
+  ConnectionConfig conn;
+  conn.first = {0, "node_a"};
+  conn.second = {0, "node_b"};
+  config.connections.push_back(conn);
+
+  // Should throw when generating node_b (which tries to create endpoint for node_a with invalid transport)
+  EXPECT_THROW(GeneratedNode(config, "node_b"), NodeBuilderException);
+}
+
+TEST(InvalidTransportTest, SerialTransportIsValid)
+{
+  Config config;
+
+  NodeConfig node_a;
+  node_a.name = "node_a";
+  node_a.id = 1;
+  node_a.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB0", "", 0};
+
+  NodeConfig node_b;
+  node_b.name = "node_b";
+  node_b.id = 2;
+  node_b.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB1", "", 0};
+
+  config.nodes["node_a"] = node_a;
+  config.nodes["node_b"] = node_b;
+
+  ConnectionConfig conn;
+  conn.first = {0, "node_a"};
+  conn.second = {0, "node_b"};
+  config.connections.push_back(conn);
+
+  SignalConfig sig("test_signal", 100, "int32");
+  config.signals.push_back(sig);
+
+  BundleConfig bundle;
+  bundle.name = "test_bundle";
+  bundle.id = 10;
+  bundle.period_ms = 100;
+  bundle.producers = {"node_a"};
+  bundle.consumers = {"node_b"};
+  bundle.signals = {100};
+  config.bundles.push_back(bundle);
+
+  // Should not throw - serial is a valid transport
+  EXPECT_NO_THROW(GeneratedNode(config, "node_a"));
+}
+
+// ============================================================================
+// Node Filtering Tests
+// ============================================================================
+
+Config create_multi_node_config()
+{
+  Config config;
+
+  // Create 4 nodes in a chain: A <-> B <-> C <-> D
+  NodeConfig node_a;
+  node_a.name = "node_a";
+  node_a.id = 1;
+  node_a.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB0", "", 0};
+
+  NodeConfig node_b;
+  node_b.name = "node_b";
+  node_b.id = 2;
+  node_b.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB1", "", 0};
+
+  NodeConfig node_c;
+  node_c.name = "node_c";
+  node_c.id = 3;
+  node_c.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB2", "", 0};
+
+  NodeConfig node_d;
+  node_d.name = "node_d";
+  node_d.id = 4;
+  node_d.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB3", "", 0};
+
+  config.nodes["node_a"] = node_a;
+  config.nodes["node_b"] = node_b;
+  config.nodes["node_c"] = node_c;
+  config.nodes["node_d"] = node_d;
+
+  // Connections: A <-> B, B <-> C, C <-> D
+  ConnectionConfig conn_ab;
+  conn_ab.first = {0, "node_a"};
+  conn_ab.second = {0, "node_b"};
+  config.connections.push_back(conn_ab);
+
+  ConnectionConfig conn_bc;
+  conn_bc.first = {0, "node_b"};
+  conn_bc.second = {0, "node_c"};
+  config.connections.push_back(conn_bc);
+
+  ConnectionConfig conn_cd;
+  conn_cd.first = {0, "node_c"};
+  conn_cd.second = {0, "node_d"};
+  config.connections.push_back(conn_cd);
+
+  // Signals
+  config.signals.push_back(SignalConfig("signal_ab", 100, "int32"));
+  config.signals.push_back(SignalConfig("signal_bc", 101, "int32"));
+  config.signals.push_back(SignalConfig("signal_cd", 102, "int32"));
+
+  // Bundles
+  BundleConfig bundle_ab;
+  bundle_ab.name = "bundle_ab";
+  bundle_ab.id = 10;
+  bundle_ab.period_ms = 100;
+  bundle_ab.producers = {"node_a"};
+  bundle_ab.consumers = {"node_b"};
+  bundle_ab.signals = {100};
+  config.bundles.push_back(bundle_ab);
+
+  BundleConfig bundle_bc;
+  bundle_bc.name = "bundle_bc";
+  bundle_bc.id = 11;
+  bundle_bc.period_ms = 100;
+  bundle_bc.producers = {"node_b"};
+  bundle_bc.consumers = {"node_c"};
+  bundle_bc.signals = {101};
+  config.bundles.push_back(bundle_bc);
+
+  BundleConfig bundle_cd;
+  bundle_cd.name = "bundle_cd";
+  bundle_cd.id = 12;
+  bundle_cd.period_ms = 100;
+  bundle_cd.producers = {"node_c"};
+  bundle_cd.consumers = {"node_d"};
+  bundle_cd.signals = {102};
+  config.bundles.push_back(bundle_cd);
+
+  return config;
+}
+
+TEST(NodeFilteringTest, FilteredNodeOnlySeesRelevantSignals)
+{
+  Config config = create_multi_node_config();
+  Config filtered_config = filter_for_target(config, "node_a");
+
+  // Node A should only see signal 100 (bundle_ab)
+  GeneratedNode node_a(filtered_config, "node_a");
+  EXPECT_NE(proton_registry_get_signal(node_a.registry(), 100, nullptr), nullptr);
+  EXPECT_EQ(proton_registry_get_signal(node_a.registry(), 101, nullptr), nullptr);
+  EXPECT_EQ(proton_registry_get_signal(node_a.registry(), 102, nullptr), nullptr);
+}
+
+TEST(NodeFilteringTest, FilteredNodeOnlySeesRelevantBundles)
+{
+  Config config = create_multi_node_config();
+  Config filtered_config = filter_for_target(config, "node_a");
+
+  // Node A should only see bundle 10 (bundle_ab)
+  GeneratedNode node_a(filtered_config, "node_a");
+  EXPECT_NE(proton_registry_get_bundle(node_a.registry(), 10, nullptr), nullptr);
+  EXPECT_EQ(proton_registry_get_bundle(node_a.registry(), 11, nullptr), nullptr);
+  EXPECT_EQ(proton_registry_get_bundle(node_a.registry(), 12, nullptr), nullptr);
+}
+
+TEST(NodeFilteringTest, MiddleNodeSeesAdjacentBundles)
+{
+  Config config = create_multi_node_config();
+  Config filtered_config = filter_for_target(config, "node_b");
+
+  // Node B should see bundles 10 and 11
+  GeneratedNode node_b(filtered_config, "node_b");
+  EXPECT_NE(proton_registry_get_bundle(node_b.registry(), 10, nullptr), nullptr);
+  EXPECT_NE(proton_registry_get_bundle(node_b.registry(), 11, nullptr), nullptr);
+  EXPECT_EQ(proton_registry_get_bundle(node_b.registry(), 12, nullptr), nullptr);
+}
+
+TEST(NodeFilteringTest, MiddleNodeSeesAdjacentSignals)
+{
+  Config config = create_multi_node_config();
+  Config filtered_config = filter_for_target(config, "node_b");
+
+  // Node B should see signals 100 and 101
+  GeneratedNode node_b(filtered_config, "node_b");
+  EXPECT_NE(proton_registry_get_signal(node_b.registry(), 100, nullptr), nullptr);
+  EXPECT_NE(proton_registry_get_signal(node_b.registry(), 101, nullptr), nullptr);
+  EXPECT_EQ(proton_registry_get_signal(node_b.registry(), 102, nullptr), nullptr);
+}
+
+TEST(NodeFilteringTest, EndNodeOnlySeesItsBundle)
+{
+  Config config = create_multi_node_config();
+  Config filtered_config = filter_for_target(config, "node_d");
+
+  // Node D should only see bundle 12 (bundle_cd)
+  GeneratedNode node_d(filtered_config, "node_d");
+  EXPECT_EQ(proton_registry_get_bundle(node_d.registry(), 10, nullptr), nullptr);
+  EXPECT_EQ(proton_registry_get_bundle(node_d.registry(), 11, nullptr), nullptr);
+  EXPECT_NE(proton_registry_get_bundle(node_d.registry(), 12, nullptr), nullptr);
+}
+
+TEST(NodeFilteringTest, NodeOnlyHasPeersItConnectsTo)
+{
+  Config config = create_multi_node_config();
+
+  // Node A should only have node B as a peer (1 peer)
+  Config node_a_config = filter_for_target(config, "node_a");
+  GeneratedNode node_a(node_a_config, "node_a");
+  EXPECT_EQ(node_a.node()->num_peers, 1);
+
+  // Node B should have nodes A and C as peers (2 peers)
+  Config node_b_config = filter_for_target(config, "node_b");
+  GeneratedNode node_b(node_b_config, "node_b");
+  EXPECT_EQ(node_b.node()->num_peers, 2);
+
+  // Node D should only have node C as a peer (1 peer)
+  Config node_d_config = filter_for_target(config, "node_d");
+  GeneratedNode node_d(node_d_config, "node_d");
+  EXPECT_EQ(node_d.node()->num_peers, 1);
+}
+
+TEST(NodeFilteringTest, InvalidTargetNodeThrows)
+{
+  Config config = create_multi_node_config();
+
+  EXPECT_THROW(filter_for_target(config, "nonexistent_node"), NodeBuilderException);
+}
+
+TEST(NodeFilteringTest, FilterForTargetFunction)
+{
+  Config config = create_multi_node_config();
+
+  Config filtered = filter_for_target(config, "node_a");
+
+  // Should have node_a and node_b (connected peer)
+  EXPECT_TRUE(filtered.nodes.contains("node_a"));
+  EXPECT_TRUE(filtered.nodes.contains("node_b"));
+  EXPECT_FALSE(filtered.nodes.contains("node_c"));
+  EXPECT_FALSE(filtered.nodes.contains("node_d"));
+
+  // Should have 1 connection (a <-> b)
+  EXPECT_EQ(filtered.connections.size(), 1);
+
+  // Should have 1 bundle (bundle_ab)
+  EXPECT_EQ(filtered.bundles.size(), 1);
+  EXPECT_EQ(filtered.bundles[0].id, 10);
+
+  // Should have 1 signal (signal_ab)
+  EXPECT_EQ(filtered.signals.size(), 1);
+  EXPECT_EQ(filtered.signals[0].id, 100);
 }
 
 int main(int argc, char ** argv)

--- a/cpp/tests/node_builder_generator_test.cpp
+++ b/cpp/tests/node_builder_generator_test.cpp
@@ -1,0 +1,410 @@
+/*
+ * Copyright 2026 Rockwell Automation Technologies, Inc., All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Tom Wallis (thomas.wallis@rockwellautomation.com)
+ */
+
+#include <gtest/gtest.h>
+#include <cstring>
+#include <functional>
+#include <sstream>
+#include <string>
+
+#include "protoncpp/node_builder/generator.hpp"
+
+using namespace proton::node_builder;
+
+// Helper to create a minimal valid config for testing
+Config create_base_config()
+{
+  Config config;
+
+  // Add two nodes
+  NodeConfig node_a;
+  node_a.name = "node_a";
+  node_a.id = 1;
+  node_a.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.1", 5000};
+
+  NodeConfig node_b;
+  node_b.name = "node_b";
+  node_b.id = 2;
+  node_b.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.2", 5000};
+
+  NodeConfig node_c;
+  node_c.name = "node_c";
+  node_c.id = 3;
+  node_c.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.3", 5000};
+
+  config.nodes["node_a"] = node_a;
+  config.nodes["node_b"] = node_b;
+  config.nodes["node_c"] = node_c;
+
+  // Add connections: a <-> b, b <-> c
+  ConnectionConfig conn_ab;
+  conn_ab.first = {0, "node_a"};
+  conn_ab.second = {0, "node_b"};
+  config.connections.push_back(conn_ab);
+
+  ConnectionConfig conn_bc;
+  conn_bc.first = {0, "node_b"};
+  conn_bc.second = {0, "node_c"};
+  config.connections.push_back(conn_bc);
+
+  // Add signals
+  SignalConfig signal1;
+  signal1.name = "signal_1";
+  signal1.id = 100;
+  signal1.type_string = "int32";
+  signal1.capacity = 0;
+  signal1.has_default_value = false;
+  config.signals.push_back(signal1);
+
+  SignalConfig signal2;
+  signal2.name = "signal_2";
+  signal2.id = 101;
+  signal2.type_string = "double";
+  signal2.capacity = 0;
+  signal2.has_default_value = false;
+  config.signals.push_back(signal2);
+
+  SignalConfig signal3;
+  signal3.name = "signal_3";
+  signal3.id = 102;
+  signal3.type_string = "bool";
+  signal3.capacity = 0;
+  signal3.has_default_value = false;
+  config.signals.push_back(signal3);
+
+  // Add bundles
+  BundleConfig bundle1;
+  bundle1.name = "bundle_ab";
+  bundle1.id = 10;
+  bundle1.period_ms = 100;
+  bundle1.producers = {"node_a"};
+  bundle1.consumers = {"node_b"};
+  bundle1.signals = {100, 101};
+  config.bundles.push_back(bundle1);
+
+  BundleConfig bundle2;
+  bundle2.name = "bundle_bc";
+  bundle2.id = 11;
+  bundle2.period_ms = 200;
+  bundle2.producers = {"node_b"};
+  bundle2.consumers = {"node_c"};
+  bundle2.signals = {102};
+  config.bundles.push_back(bundle2);
+
+  return config;
+}
+
+// ============================================================================
+// find_duplicates tests
+// ============================================================================
+
+TEST(FindDuplicates, NoDuplicatesDoesNotThrow)
+{
+  std::vector<uint32_t> ids = {1, 2, 3, 4, 5};
+  EXPECT_NO_THROW(find_duplicates<uint32_t>(ids, "test IDs"));
+}
+
+TEST(FindDuplicates, EmptyListDoesNotThrow)
+{
+  std::vector<uint32_t> ids = {};
+  EXPECT_NO_THROW(find_duplicates<uint32_t>(ids, "test IDs"));
+}
+
+TEST(FindDuplicates, SingleElementDoesNotThrow)
+{
+  std::vector<uint32_t> ids = {42};
+  EXPECT_NO_THROW(find_duplicates<uint32_t>(ids, "test IDs"));
+}
+
+TEST(FindDuplicates, DuplicateIntegersThrows)
+{
+  std::vector<uint32_t> ids = {1, 2, 3, 2, 4};
+  EXPECT_THROW(find_duplicates<uint32_t>(ids, "test IDs"), NodeBuilderException);
+}
+
+TEST(FindDuplicates, MultipleDuplicatesThrows)
+{
+  std::vector<uint32_t> ids = {1, 2, 1, 3, 2, 4};
+  EXPECT_THROW(find_duplicates<uint32_t>(ids, "test IDs"), NodeBuilderException);
+}
+
+TEST(FindDuplicates, DuplicateStringsThrows)
+{
+  std::vector<std::string> names = {"alpha", "beta", "alpha"};
+  EXPECT_THROW(find_duplicates<std::string>(names, "test names"), NodeBuilderException);
+}
+
+TEST(FindDuplicates, NoDuplicateStringsDoesNotThrow)
+{
+  std::vector<std::string> names = {"alpha", "beta", "gamma"};
+  EXPECT_NO_THROW(find_duplicates<std::string>(names, "test names"));
+}
+
+// ============================================================================
+// validate tests
+// ============================================================================
+
+TEST(Validate, ValidConfigDoesNotThrow)
+{
+  Config config = create_base_config();
+  EXPECT_NO_THROW(validate(config));
+}
+
+TEST(Validate, EmptyConfigDoesNotThrow)
+{
+  Config config;
+  EXPECT_NO_THROW(validate(config));
+}
+
+TEST(Validate, DuplicateSignalIdThrows)
+{
+  Config config = create_base_config();
+
+  SignalConfig dup_signal;
+  dup_signal.name = "signal_dup";
+  dup_signal.id = 100;  // Duplicate of signal_1
+  dup_signal.type_string = "float";
+  config.signals.push_back(dup_signal);
+
+  EXPECT_THROW(validate(config), NodeBuilderException);
+}
+
+TEST(Validate, DuplicateSignalNameThrows)
+{
+  Config config = create_base_config();
+
+  SignalConfig dup_signal;
+  dup_signal.name = "signal_1";  // Duplicate name
+  dup_signal.id = 999;
+  dup_signal.type_string = "float";
+  config.signals.push_back(dup_signal);
+
+  EXPECT_THROW(validate(config), NodeBuilderException);
+}
+
+TEST(Validate, DuplicateBundleIdThrows)
+{
+  Config config = create_base_config();
+
+  BundleConfig dup_bundle;
+  dup_bundle.name = "bundle_dup";
+  dup_bundle.id = 10;  // Duplicate of bundle_ab
+  dup_bundle.period_ms = 50;
+  dup_bundle.producers = {"node_a"};
+  dup_bundle.consumers = {"node_b"};
+  config.bundles.push_back(dup_bundle);
+
+  EXPECT_THROW(validate(config), NodeBuilderException);
+}
+
+TEST(Validate, DuplicateBundleNameThrows)
+{
+  Config config = create_base_config();
+
+  BundleConfig dup_bundle;
+  dup_bundle.name = "bundle_ab";  // Duplicate name
+  dup_bundle.id = 999;
+  dup_bundle.period_ms = 50;
+  dup_bundle.producers = {"node_a"};
+  dup_bundle.consumers = {"node_b"};
+  config.bundles.push_back(dup_bundle);
+
+  EXPECT_THROW(validate(config), NodeBuilderException);
+}
+
+TEST(Validate, DuplicateNodeIdThrows)
+{
+  Config config = create_base_config();
+
+  NodeConfig dup_node;
+  dup_node.name = "node_d";
+  dup_node.id = 1;  // Duplicate of node_a
+  config.nodes["node_d"] = dup_node;
+
+  EXPECT_THROW(validate(config), NodeBuilderException);
+}
+
+// ============================================================================
+// filter_for_target tests
+// ============================================================================
+
+TEST(FilterForTarget, InvalidTargetThrows)
+{
+  Config config = create_base_config();
+  EXPECT_THROW(filter_for_target(config, "nonexistent_node"), NodeBuilderException);
+}
+
+TEST(FilterForTarget, TargetNodeIncluded)
+{
+  Config config = create_base_config();
+  Config filtered = filter_for_target(config, "node_a");
+
+  EXPECT_TRUE(filtered.nodes.contains("node_a"));
+  EXPECT_EQ(filtered.nodes.at("node_a").id, 1);
+}
+
+TEST(FilterForTarget, ConnectedPeerIncluded)
+{
+  Config config = create_base_config();
+  Config filtered = filter_for_target(config, "node_a");
+
+  // node_a is connected to node_b
+  EXPECT_TRUE(filtered.nodes.contains("node_b"));
+  // node_a is NOT connected to node_c
+  EXPECT_FALSE(filtered.nodes.contains("node_c"));
+}
+
+TEST(FilterForTarget, MiddleNodeIncludesBothPeers)
+{
+  Config config = create_base_config();
+  Config filtered = filter_for_target(config, "node_b");
+
+  // node_b is connected to both node_a and node_c
+  EXPECT_TRUE(filtered.nodes.contains("node_a"));
+  EXPECT_TRUE(filtered.nodes.contains("node_b"));
+  EXPECT_TRUE(filtered.nodes.contains("node_c"));
+}
+
+TEST(FilterForTarget, OnlyRelevantConnectionsIncluded)
+{
+  Config config = create_base_config();
+  Config filtered = filter_for_target(config, "node_a");
+
+  // Only the a <-> b connection should be included
+  EXPECT_EQ(filtered.connections.size(), 1);
+  EXPECT_TRUE(
+    (filtered.connections[0].first.node == "node_a" &&
+     filtered.connections[0].second.node == "node_b") ||
+    (filtered.connections[0].first.node == "node_b" &&
+     filtered.connections[0].second.node == "node_a"));
+}
+
+TEST(FilterForTarget, MiddleNodeIncludesAllConnections)
+{
+  Config config = create_base_config();
+  Config filtered = filter_for_target(config, "node_b");
+
+  // Both connections should be included
+  EXPECT_EQ(filtered.connections.size(), 2);
+}
+
+TEST(FilterForTarget, OnlyProducerBundlesIncluded)
+{
+  Config config = create_base_config();
+  Config filtered = filter_for_target(config, "node_a");
+
+  // node_a produces bundle_ab, but doesn't produce/consume bundle_bc
+  EXPECT_EQ(filtered.bundles.size(), 1);
+  EXPECT_EQ(filtered.bundles[0].name, "bundle_ab");
+}
+
+TEST(FilterForTarget, OnlyConsumerBundlesIncluded)
+{
+  Config config = create_base_config();
+  Config filtered = filter_for_target(config, "node_c");
+
+  // node_c consumes bundle_bc only
+  EXPECT_EQ(filtered.bundles.size(), 1);
+  EXPECT_EQ(filtered.bundles[0].name, "bundle_bc");
+}
+
+TEST(FilterForTarget, MiddleNodeIncludesAllBundles)
+{
+  Config config = create_base_config();
+  Config filtered = filter_for_target(config, "node_b");
+
+  // node_b consumes bundle_ab and produces bundle_bc
+  EXPECT_EQ(filtered.bundles.size(), 2);
+}
+
+TEST(FilterForTarget, OnlyRelevantSignalsIncluded)
+{
+  Config config = create_base_config();
+  Config filtered = filter_for_target(config, "node_a");
+
+  // bundle_ab uses signal_1 (100) and signal_2 (101), not signal_3 (102)
+  EXPECT_EQ(filtered.signals.size(), 2);
+
+  bool has_signal_100 = false;
+  bool has_signal_101 = false;
+  for (const auto & sig : filtered.signals)
+  {
+    if (sig.id == 100) has_signal_100 = true;
+    if (sig.id == 101) has_signal_101 = true;
+  }
+  EXPECT_TRUE(has_signal_100);
+  EXPECT_TRUE(has_signal_101);
+}
+
+TEST(FilterForTarget, NodeCOnlyHasSignal3)
+{
+  Config config = create_base_config();
+  Config filtered = filter_for_target(config, "node_c");
+
+  // bundle_bc only uses signal_3 (102)
+  EXPECT_EQ(filtered.signals.size(), 1);
+  EXPECT_EQ(filtered.signals[0].id, 102);
+}
+
+TEST(FilterForTarget, MiddleNodeIncludesAllSignals)
+{
+  Config config = create_base_config();
+  Config filtered = filter_for_target(config, "node_b");
+
+  // node_b uses all bundles, so all signals
+  EXPECT_EQ(filtered.signals.size(), 3);
+}
+
+TEST(FilterForTarget, IsolatedNodeHasNoBundles)
+{
+  Config config = create_base_config();
+
+  // Add an isolated node with no connections or bundles
+  NodeConfig isolated;
+  isolated.name = "isolated";
+  isolated.id = 99;
+  config.nodes["isolated"] = isolated;
+
+  Config filtered = filter_for_target(config, "isolated");
+
+  EXPECT_EQ(filtered.nodes.size(), 1);
+  EXPECT_TRUE(filtered.nodes.contains("isolated"));
+  EXPECT_EQ(filtered.connections.size(), 0);
+  EXPECT_EQ(filtered.bundles.size(), 0);
+  EXPECT_EQ(filtered.signals.size(), 0);
+}
+
+TEST(FilterForTarget, ValidationRunsBeforeFiltering)
+{
+  Config config = create_base_config();
+
+  // Add a duplicate signal ID to make config invalid
+  SignalConfig dup_signal;
+  dup_signal.name = "dup";
+  dup_signal.id = 100;  // Duplicate
+  config.signals.push_back(dup_signal);
+
+  // Should throw during validation, even though target exists
+  EXPECT_THROW(filter_for_target(config, "node_a"), NodeBuilderException);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Part of the larger proton re-architecture [here](https://otto-ra.atlassian.net/wiki/spaces/PFT/pages/344948755/Proton+Reorganization+and+Core+Library) (internal CPR/OTTO employee eyes only 👀 )

The final part of the runtime node generation: actually generating a `proton_core_node_t` and `proton_registry_t`

This PR also fixes a bug in the registry encode/decode where if a bytes or string type signal value mutates between an encode and decode, the incorrect length is reported back, specifically if the length has changed.

This _should_ be the last part of the larger proton re-architecture.