### PR TITLE
Fix: STL types for signals

### DIFF
--- a/core/src/registry.c
+++ b/core/src/registry.c
@@ -406,7 +406,7 @@ proton_status_e proton_signal_get_bytes(
 proton_status_e proton_signal_set_bytes(
   const proton_registry_t * registry, uint32_t signal_id, const uint8_t * data, size_t len)
 {
-  if (registry == NULL || data == NULL)
+  if (registry == NULL || (data == NULL && len > 0))
   {
     return PROTON_NULL_PTR_ERROR;
   }
@@ -424,7 +424,16 @@ proton_status_e proton_signal_set_bytes(
   {
     return PROTON_INSUFFICIENT_BUFFER_ERROR;
   }
-  memcpy(desc->signal.signal.bytes_value, data, len);
+
+  if (len == 0)
+  {
+    memset(desc->signal.signal.bytes_value, 0, desc->capacity);
+  }
+  else
+  {
+    memcpy(desc->signal.signal.bytes_value, data, len);
+  }
+
   desc->value_size = len;
   return PROTON_OK;
 }

--- a/core/tests/core/registry_test.cpp
+++ b/core/tests/core/registry_test.cpp
@@ -208,6 +208,25 @@ TEST(SignalRegistry, SetBytesExcessiveLength)
   free(registry.signal_registry);
 }
 
+TEST(SignalRegistry, SetEmptyBytes)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  proton_status_e status =
+    proton_signal_set_bytes(&registry, PROTON_SIGNAL_BYTES_VALUE_ID, nullptr, 0);
+  EXPECT_EQ(status, PROTON_OK);
+
+  uint8_t read_value[PROTON_SIGNAL_DEFAULT_BYTES_CAPACITY] = {0xFF};
+  size_t new_len = 0xFF;
+  status = proton_signal_get_bytes(
+    &registry, PROTON_SIGNAL_BYTES_VALUE_ID, read_value, PROTON_SIGNAL_DEFAULT_BYTES_CAPACITY,
+    &new_len);
+
+  EXPECT_EQ(status, PROTON_OK);
+  EXPECT_EQ(new_len, 0);
+
+  free(registry.signal_registry);
+}
+
 TEST(SignalRegistry, SetStringNotNullTerminated)
 {
   proton_registry_t registry = copy_default_registry(&g_proton_registry);

--- a/cpp/include/protoncpp/signal_access.hpp
+++ b/cpp/include/protoncpp/signal_access.hpp
@@ -26,6 +26,19 @@
 #include <cstdint>
 #include <type_traits>
 
+#if PROTON_ENABLE_ALLOC
+
+#include <string>
+#include <vector>
+
+#endif  // PROTON_ENABLE_ALLOC
+
+#if __cplusplus >= 202002L
+
+#include <span>
+
+#endif  // __cplusplus >= 202002L
+
 namespace proton
 {
 
@@ -110,7 +123,7 @@ public:
 #else
   // No virtual destructor in embedded mode (no RTTI)
   ~SignalBase() = default;
-#endif
+#endif  // PROTON_ENABLE_ALLOC
 
   uint32_t id() const noexcept { return id_; }
 
@@ -130,6 +143,22 @@ protected:
   uint32_t id_;
 };
 
+namespace detail
+{
+// Helper trait to detect primitive signal types (types with direct SignalAccess support)
+template <typename T>
+struct is_primitive_signal_type
+: std::bool_constant<
+    std::is_same_v<T, double> || std::is_same_v<T, float> || std::is_same_v<T, int32_t> ||
+    std::is_same_v<T, int64_t> || std::is_same_v<T, uint32_t> || std::is_same_v<T, uint64_t> ||
+    std::is_same_v<T, bool>>
+{
+};
+
+template <typename T>
+inline constexpr bool is_primitive_signal_type_v = is_primitive_signal_type<T>::value;
+}  // namespace detail
+
 /**
  * @class Signal typed wrapper around a SignalBase. Does not require RTTI, but if
  * RTTI is enabled, it can be safely stored as a SignalBase pointer and dynamically cast back to Signal<T>.
@@ -140,9 +169,17 @@ class Signal : public SignalBase
 public:
   constexpr explicit Signal(proton_registry_t * registry, uint32_t id) : SignalBase(registry, id) {}
 
-  proton_status_e get(T & out) const noexcept { return SignalAccess(registry_).get(id_, out); }
+  template <typename U = T, std::enable_if_t<detail::is_primitive_signal_type_v<U>, int> = 0>
+  proton_status_e get(U & out) const noexcept
+  {
+    return SignalAccess(registry_).get(id_, out);
+  }
 
-  proton_status_e set(T value) noexcept { return SignalAccess(registry_).set(id_, value); }
+  template <typename U = T, std::enable_if_t<detail::is_primitive_signal_type_v<U>, int> = 0>
+  proton_status_e set(U value) noexcept
+  {
+    return SignalAccess(registry_).set(id_, value);
+  }
 
   proton_status_e get(char * buf, size_t cap, size_t & len) const noexcept
   {
@@ -173,6 +210,79 @@ public:
       "set(const uint8_t*, size_t) is only valid for Signal<uint8_t*>");
     return SignalAccess(registry_).set(id_, buf, len);
   }
+
+#if PROTON_ENABLE_ALLOC
+
+  // Some convenience methods for STL types when allocations are allowed
+
+  proton_status_e get(std::string & str) const noexcept
+  {
+    static_assert(
+      std::is_same_v<T, std::string>,
+      "get(std::string&, size_t&) is only valid for Signal<std::string>");
+
+    size_t len;
+    const proton_status_e status =
+      SignalAccess(registry_).get(id_, str.data(), str.capacity(), len);
+
+    if (status == PROTON_OK)
+    {
+      str.resize(len);
+    }
+
+    return status;
+  }
+
+  proton_status_e set(const std::string & str) noexcept
+  {
+    static_assert(
+      std::is_same_v<T, std::string>, "set(std::string&) is only valid for Signal<std::string>");
+
+    return SignalAccess(registry_).set(id_, str.c_str(), str.size() + 1);
+  }
+
+  proton_status_e get(std::vector<uint8_t> & buf) const noexcept
+  {
+    static_assert(
+      std::is_same_v<T, std::vector<uint8_t>>,
+      "get(std::vector<uint8_t>&) is only valid for Signal<std::vector<uint8_t>>");
+
+    size_t len;
+    const proton_status_e status =
+      SignalAccess(registry_).get(id_, buf.data(), buf.capacity(), len);
+
+    if (status == PROTON_OK)
+    {
+      buf.resize(len);
+    }
+
+    return status;
+  }
+
+  proton_status_e set(const std::vector<uint8_t> & buf) noexcept
+  {
+    static_assert(
+      std::is_same_v<T, std::vector<uint8_t>>,
+      "set(std::vector<uint8_t>&) is only valid for Signal<std::vector<uint8_t>>");
+
+    return SignalAccess(registry_).set(id_, buf.data(), buf.size());
+  }
+
+#endif  // PROTON_ENABLE_ALLOC
+
+#if __cplusplus >= 202002L
+
+  proton_status_e get(std::span<uint8_t> buf, size_t & len) const noexcept
+  {
+    return get(buf.data(), buf.size(), len);
+  }
+
+  proton_status_e set(std::span<const uint8_t> buf) const noexcept
+  {
+    return set(buf.data(), buf.size());
+  }
+
+#endif  // __cplusplus >= 202002L
 };
 
 }  // namespace proton

--- a/cpp/include/protoncpp/signal_access.hpp
+++ b/cpp/include/protoncpp/signal_access.hpp
@@ -277,10 +277,7 @@ public:
     return get(buf.data(), buf.size(), len);
   }
 
-  proton_status_e set(std::span<const uint8_t> buf) const noexcept
-  {
-    return set(buf.data(), buf.size());
-  }
+  proton_status_e set(std::span<const uint8_t> buf) noexcept { return set(buf.data(), buf.size()); }
 
 #endif  // __cplusplus >= 202002L
 };

--- a/cpp/include/protoncpp/signal_access.hpp
+++ b/cpp/include/protoncpp/signal_access.hpp
@@ -225,9 +225,9 @@ public:
     const proton_status_e status =
       SignalAccess(registry_).get(id_, str.data(), str.capacity(), len);
 
-    if (status == PROTON_OK)
+    if (status == PROTON_OK && len > 0)
     {
-      str.resize(len);
+      str.resize(len - 1);
     }
 
     return status;

--- a/cpp/tests/registry_test.cpp
+++ b/cpp/tests/registry_test.cpp
@@ -924,7 +924,7 @@ TEST(SignalStdString, GetDefaultString)
   std::string buf(PROTON_SIGNAL_DEFAULT_STRING_CAPACITY, '\0');
   proton_status_e status = signal.get(buf);
   ASSERT_EQ(status, PROTON_OK);
-  EXPECT_EQ(buf.size(), 4);  // "foo" + null terminator
+  EXPECT_EQ(buf.size(), 3);
   EXPECT_STREQ(buf.c_str(), "foo");
 
   free(registry.signal_registry);
@@ -942,7 +942,7 @@ TEST(SignalStdString, SetAndGetString)
   std::string buf(PROTON_SIGNAL_STRING_VALUE_CAPACITY, '\0');
   status = signal.get(buf);
   ASSERT_EQ(status, PROTON_OK);
-  EXPECT_EQ(buf.size(), 4);  // "bar" + null terminator
+  EXPECT_EQ(buf.size(), 3);
   EXPECT_STREQ(buf.c_str(), "bar");
 
   free(registry.signal_registry);
@@ -960,7 +960,7 @@ TEST(SignalStdString, SetEmptyString)
   std::string buf(PROTON_SIGNAL_STRING_VALUE_CAPACITY, '\0');
   status = signal.get(buf);
   ASSERT_EQ(status, PROTON_OK);
-  EXPECT_EQ(buf.size(), 1);  // Just null terminator
+  EXPECT_EQ(buf.size(), 0);
   EXPECT_STREQ(buf.c_str(), "");
 
   free(registry.signal_registry);
@@ -993,7 +993,7 @@ TEST(SignalStdString, SetStringAtExactCapacity)
   std::string buf(PROTON_SIGNAL_STRING_VALUE_CAPACITY, '\0');
   status = signal.get(buf);
   ASSERT_EQ(status, PROTON_OK);
-  EXPECT_EQ(buf.size(), PROTON_SIGNAL_STRING_VALUE_CAPACITY);
+  EXPECT_EQ(buf.size(), PROTON_SIGNAL_STRING_VALUE_CAPACITY - 1);
   EXPECT_STREQ(buf.c_str(), at_capacity.c_str());
 
   free(registry.signal_registry);
@@ -1029,7 +1029,7 @@ TEST(SignalStdString, SetAndGetLongString)
   std::string buf(PROTON_SIGNAL_REALLY_LONG_STRING_CAPACITY, '\0');
   status = signal.get(buf);
   ASSERT_EQ(status, PROTON_OK);
-  EXPECT_EQ(buf.size(), long_value.size() + 1);  // Include null terminator
+  EXPECT_EQ(buf.size(), long_value.size());
   EXPECT_STREQ(buf.c_str(), long_value.c_str());
 
   free(registry.signal_registry);

--- a/cpp/tests/registry_test.cpp
+++ b/cpp/tests/registry_test.cpp
@@ -1043,6 +1043,150 @@ TEST(SignalStdString, SetAndGetLongString)
 
 #if PROTON_ENABLE_ALLOC
 
+TEST(SignalStdVector, GetDefaultBytes)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<std::vector<uint8_t>> signal(&registry, PROTON_SIGNAL_DEFAULT_BYTES_ID);
+
+  std::vector<uint8_t> buf(PROTON_SIGNAL_DEFAULT_BYTES_CAPACITY);
+  proton_status_e status = signal.get(buf);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(buf.size(), 3);
+  EXPECT_EQ(buf[0], 0);
+  EXPECT_EQ(buf[1], 1);
+  EXPECT_EQ(buf[2], 2);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalStdVector, SetAndGetBytes)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<std::vector<uint8_t>> signal(&registry, PROTON_SIGNAL_BYTES_VALUE_ID);
+
+  std::vector<uint8_t> new_value = {0xAA, 0xBB, 0xCC, 0xDD};
+  proton_status_e status = signal.set(new_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  std::vector<uint8_t> buf(PROTON_SIGNAL_BYTES_VALUE_CAPACITY);
+  status = signal.get(buf);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(buf.size(), 4);
+  EXPECT_EQ(buf, new_value);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalStdVector, SetEmptyBytes)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<std::vector<uint8_t>> signal(&registry, PROTON_SIGNAL_BYTES_VALUE_ID);
+
+  std::vector<uint8_t> empty_value;
+  empty_value.resize(0);
+  proton_status_e status = signal.set(empty_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  std::vector<uint8_t> buf(PROTON_SIGNAL_BYTES_VALUE_CAPACITY);
+  status = signal.get(buf);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(buf.size(), 0);
+  EXPECT_TRUE(buf.empty());
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalStdVector, SetBytesExceedsCapacity)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<std::vector<uint8_t>> signal(&registry, PROTON_SIGNAL_BYTES_VALUE_ID);
+
+  // PROTON_SIGNAL_BYTES_VALUE_CAPACITY is the max, so exceed it
+  std::vector<uint8_t> too_long(PROTON_SIGNAL_BYTES_VALUE_CAPACITY + 10, 0xFF);
+  proton_status_e status = signal.set(too_long);
+  EXPECT_EQ(status, PROTON_INSUFFICIENT_BUFFER_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalStdVector, SetBytesAtExactCapacity)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<std::vector<uint8_t>> signal(&registry, PROTON_SIGNAL_BYTES_VALUE_ID);
+
+  std::vector<uint8_t> at_capacity(PROTON_SIGNAL_BYTES_VALUE_CAPACITY, 0xAB);
+  proton_status_e status = signal.set(at_capacity);
+  ASSERT_EQ(status, PROTON_OK);
+
+  std::vector<uint8_t> buf(PROTON_SIGNAL_BYTES_VALUE_CAPACITY);
+  status = signal.get(buf);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(buf.size(), PROTON_SIGNAL_BYTES_VALUE_CAPACITY);
+  EXPECT_EQ(buf, at_capacity);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalStdVector, GetWithInsufficientBufferCapacity)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<std::vector<uint8_t>> signal(&registry, PROTON_SIGNAL_REALLY_LONG_BYTES_ID);
+
+  // First set long bytes
+  std::vector<uint8_t> long_value(PROTON_SIGNAL_REALLY_LONG_BYTES_CAPACITY, 0xCD);
+  proton_status_e status = signal.set(long_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  // Try to read with a buffer that's too small
+  std::vector<uint8_t> small_buf(1);  // Only 1 byte capacity
+  status = signal.get(small_buf);
+  EXPECT_EQ(status, PROTON_INSUFFICIENT_BUFFER_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalStdVector, SetAndGetLongBytes)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<std::vector<uint8_t>> signal(&registry, PROTON_SIGNAL_REALLY_LONG_BYTES_ID);
+
+  std::vector<uint8_t> long_value(PROTON_SIGNAL_REALLY_LONG_BYTES_CAPACITY, 0xEF);
+  proton_status_e status = signal.set(long_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  std::vector<uint8_t> buf(PROTON_SIGNAL_REALLY_LONG_BYTES_CAPACITY);
+  status = signal.get(buf);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(buf.size(), long_value.size());
+  EXPECT_EQ(buf, long_value);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalStdVector, GetInvalidSignalId)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<std::vector<uint8_t>> signal(&registry, 0x9999);
+
+  std::vector<uint8_t> buf(64);
+  proton_status_e status = signal.get(buf);
+  EXPECT_EQ(status, PROTON_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalStdVector, SetInvalidSignalId)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<std::vector<uint8_t>> signal(&registry, 0x9999);
+
+  std::vector<uint8_t> value = {0x01, 0x02};
+  proton_status_e status = signal.set(value);
+  EXPECT_EQ(status, PROTON_ERROR);
+
+  free(registry.signal_registry);
+}
+
 #endif  // PROTON_ENABLE_ALLOC
 
 // =============================================================================

--- a/cpp/tests/registry_test.cpp
+++ b/cpp/tests/registry_test.cpp
@@ -911,6 +911,149 @@ TEST(SignalBytes, SetInvalidSignalId)
 }
 
 // =============================================================================
+// Tests for Signal<std::string>
+// =============================================================================
+
+#if PROTON_ENABLE_ALLOC
+
+TEST(SignalStdString, GetDefaultString)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<std::string> signal(&registry, PROTON_SIGNAL_DEFAULT_STRING_ID);
+
+  std::string buf(PROTON_SIGNAL_DEFAULT_STRING_CAPACITY, '\0');
+  proton_status_e status = signal.get(buf);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(buf.size(), 4);  // "foo" + null terminator
+  EXPECT_STREQ(buf.c_str(), "foo");
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalStdString, SetAndGetString)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<std::string> signal(&registry, PROTON_SIGNAL_STRING_VALUE_ID);
+
+  std::string new_value = "bar";
+  proton_status_e status = signal.set(new_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  std::string buf(PROTON_SIGNAL_STRING_VALUE_CAPACITY, '\0');
+  status = signal.get(buf);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(buf.size(), 4);  // "bar" + null terminator
+  EXPECT_STREQ(buf.c_str(), "bar");
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalStdString, SetEmptyString)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<std::string> signal(&registry, PROTON_SIGNAL_STRING_VALUE_ID);
+
+  std::string empty_value;
+  proton_status_e status = signal.set(empty_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  std::string buf(PROTON_SIGNAL_STRING_VALUE_CAPACITY, '\0');
+  status = signal.get(buf);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(buf.size(), 1);  // Just null terminator
+  EXPECT_STREQ(buf.c_str(), "");
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalStdString, SetStringExceedsCapacity)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<std::string> signal(&registry, PROTON_SIGNAL_STRING_VALUE_ID);
+
+  // PROTON_SIGNAL_STRING_VALUE_CAPACITY is 8, so a string longer than 7 chars
+  // (plus null terminator) should fail
+  std::string too_long = "this_string_is_way_too_long_for_the_buffer";
+  proton_status_e status = signal.set(too_long);
+  EXPECT_EQ(status, PROTON_INSUFFICIENT_BUFFER_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalStdString, SetStringAtExactCapacity)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<std::string> signal(&registry, PROTON_SIGNAL_STRING_VALUE_ID);
+
+  // PROTON_SIGNAL_STRING_VALUE_CAPACITY is 8, so a 7-char string + null should fit exactly
+  std::string at_capacity(PROTON_SIGNAL_STRING_VALUE_CAPACITY - 1, 'x');
+  proton_status_e status = signal.set(at_capacity);
+  ASSERT_EQ(status, PROTON_OK);
+
+  std::string buf(PROTON_SIGNAL_STRING_VALUE_CAPACITY, '\0');
+  status = signal.get(buf);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(buf.size(), PROTON_SIGNAL_STRING_VALUE_CAPACITY);
+  EXPECT_STREQ(buf.c_str(), at_capacity.c_str());
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalStdString, GetWithInsufficientBufferCapacity)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<std::string> signal(&registry, PROTON_SIGNAL_REALLY_LONG_STRING_ID);
+
+  // First set a long string
+  std::string long_value = "ipsumsedolorsitametconsecteturadipiscingeaaa";
+  proton_status_e status = signal.set(long_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  // Try to read with a buffer that's too small
+  std::string small_buf(10, '\0');  // Only 10 bytes capacity, need 46
+  status = signal.get(small_buf);
+  EXPECT_EQ(status, PROTON_INSUFFICIENT_BUFFER_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalStdString, SetAndGetLongString)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<std::string> signal(&registry, PROTON_SIGNAL_REALLY_LONG_STRING_ID);
+
+  std::string long_value = "ipsumsedolorsitametconsecteturadipiscingeaaa";
+  proton_status_e status = signal.set(long_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  std::string buf(PROTON_SIGNAL_REALLY_LONG_STRING_CAPACITY, '\0');
+  status = signal.get(buf);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(buf.size(), long_value.size() + 1);  // Include null terminator
+  EXPECT_STREQ(buf.c_str(), long_value.c_str());
+
+  free(registry.signal_registry);
+}
+
+#endif  // PROTON_ENABLE_ALLOC
+
+// =============================================================================
+// Tests for Signal<std::vector<uint8_t>>
+// =============================================================================
+
+#if PROTON_ENABLE_ALLOC
+
+#endif  // PROTON_ENABLE_ALLOC
+
+// =============================================================================
+// Tests for Signal<std::span<uint8_t>>
+// =============================================================================
+
+#if __cplusplus >= 202002L
+
+#endif  // __cplusplus >= 202002L
+
+// =============================================================================
 // SignalBase tests (no-RTTI type checking)
 // =============================================================================
 

--- a/cpp/tests/registry_test.cpp
+++ b/cpp/tests/registry_test.cpp
@@ -28,6 +28,10 @@
 #include <vector>
 #endif
 
+#if __cplusplus >= 202002L
+#include <span>
+#endif  // __cplusplus >= 202002L
+
 extern proton_registry_t g_proton_registry;
 
 using namespace proton;
@@ -1163,30 +1167,6 @@ TEST(SignalStdVector, SetAndGetLongBytes)
   free(registry.signal_registry);
 }
 
-TEST(SignalStdVector, GetInvalidSignalId)
-{
-  proton_registry_t registry = copy_default_registry(&g_proton_registry);
-  Signal<std::vector<uint8_t>> signal(&registry, 0x9999);
-
-  std::vector<uint8_t> buf(64);
-  proton_status_e status = signal.get(buf);
-  EXPECT_EQ(status, PROTON_ERROR);
-
-  free(registry.signal_registry);
-}
-
-TEST(SignalStdVector, SetInvalidSignalId)
-{
-  proton_registry_t registry = copy_default_registry(&g_proton_registry);
-  Signal<std::vector<uint8_t>> signal(&registry, 0x9999);
-
-  std::vector<uint8_t> value = {0x01, 0x02};
-  proton_status_e status = signal.set(value);
-  EXPECT_EQ(status, PROTON_ERROR);
-
-  free(registry.signal_registry);
-}
-
 #endif  // PROTON_ENABLE_ALLOC
 
 // =============================================================================
@@ -1194,6 +1174,146 @@ TEST(SignalStdVector, SetInvalidSignalId)
 // =============================================================================
 
 #if __cplusplus >= 202002L
+TEST(SignalSpan, GetDefaultBytes)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<uint8_t *> signal(&registry, PROTON_SIGNAL_DEFAULT_BYTES_ID);
+
+  std::vector<uint8_t> buf(PROTON_SIGNAL_DEFAULT_BYTES_CAPACITY);
+  size_t len;
+  std::span<uint8_t> s_buf{buf};
+  proton_status_e status = signal.get(s_buf, len);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(len, 3);
+  EXPECT_EQ(buf[0], 0);
+  EXPECT_EQ(buf[1], 1);
+  EXPECT_EQ(buf[2], 2);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalSpan, SetAndGetBytes)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<uint8_t *> signal(&registry, PROTON_SIGNAL_BYTES_VALUE_ID);
+
+  std::vector<uint8_t> new_value = {0xAA, 0xBB, 0xCC, 0xDD};
+  std::span<const uint8_t> new_value_span{new_value};
+  proton_status_e status = signal.set(new_value_span);
+  ASSERT_EQ(status, PROTON_OK);
+
+  std::vector<uint8_t> buf(PROTON_SIGNAL_BYTES_VALUE_CAPACITY);
+  std::span<uint8_t> s_buf{buf};
+  size_t len;
+  status = signal.get(s_buf, len);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(len, 4);
+  buf.resize(len);
+  EXPECT_EQ(buf, new_value);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalSpan, SetEmptyBytes)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<uint8_t *> signal(&registry, PROTON_SIGNAL_BYTES_VALUE_ID);
+
+  std::vector<uint8_t> empty_value;
+  std::span<const uint8_t> s_empty_value{empty_value};
+  proton_status_e status = signal.set(s_empty_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  std::vector<uint8_t> buf(PROTON_SIGNAL_BYTES_VALUE_CAPACITY);
+  std::span<uint8_t> s_buf{buf};
+  size_t len;
+  status = signal.get(s_buf, len);
+  ASSERT_EQ(status, PROTON_OK);
+  buf.resize(len);
+  EXPECT_EQ(len, 0);
+  EXPECT_TRUE(buf.empty());
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalSpan, SetBytesExceedsCapacity)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<uint8_t *> signal(&registry, PROTON_SIGNAL_BYTES_VALUE_ID);
+
+  // PROTON_SIGNAL_BYTES_VALUE_CAPACITY is the max, so exceed it
+  std::vector<uint8_t> too_long(PROTON_SIGNAL_BYTES_VALUE_CAPACITY + 10, 0xFF);
+  std::span<const uint8_t> s_too_long{too_long};
+  proton_status_e status = signal.set(s_too_long);
+  EXPECT_EQ(status, PROTON_INSUFFICIENT_BUFFER_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalSpan, SetBytesAtExactCapacity)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<uint8_t *> signal(&registry, PROTON_SIGNAL_BYTES_VALUE_ID);
+
+  std::vector<uint8_t> at_capacity(PROTON_SIGNAL_BYTES_VALUE_CAPACITY, 0xAB);
+  std::span<const uint8_t> s_at_capacity{at_capacity};
+  proton_status_e status = signal.set(s_at_capacity);
+  ASSERT_EQ(status, PROTON_OK);
+
+  std::vector<uint8_t> buf(PROTON_SIGNAL_BYTES_VALUE_CAPACITY);
+  std::span<uint8_t> s_buf{buf};
+  size_t len;
+  status = signal.get(s_buf, len);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(len, PROTON_SIGNAL_BYTES_VALUE_CAPACITY);
+  buf.resize(len);
+  EXPECT_EQ(buf, at_capacity);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalSpan, GetWithInsufficientBufferCapacity)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<uint8_t *> signal(&registry, PROTON_SIGNAL_REALLY_LONG_BYTES_ID);
+
+  // First set long bytes
+  std::vector<uint8_t> long_value(PROTON_SIGNAL_REALLY_LONG_BYTES_CAPACITY, 0xCD);
+  std::span<const uint8_t> s_long_value{long_value};
+  proton_status_e status = signal.set(s_long_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  // Try to read with a buffer that's too small
+  std::vector<uint8_t> small_buf(1);  // Only 1 byte capacity
+  std::span<uint8_t> s_small_buf{small_buf};
+  size_t len;
+  status = signal.get(s_small_buf, len);
+  EXPECT_EQ(status, PROTON_INSUFFICIENT_BUFFER_ERROR);
+
+  free(registry.signal_registry);
+}
+
+TEST(SignalSpan, SetAndGetLongBytes)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  Signal<uint8_t *> signal(&registry, PROTON_SIGNAL_REALLY_LONG_BYTES_ID);
+
+  std::vector<uint8_t> long_value(PROTON_SIGNAL_REALLY_LONG_BYTES_CAPACITY, 0xEF);
+  std::span<const uint8_t> s_long_value{long_value};
+  proton_status_e status = signal.set(s_long_value);
+  ASSERT_EQ(status, PROTON_OK);
+
+  std::vector<uint8_t> buf(PROTON_SIGNAL_REALLY_LONG_BYTES_CAPACITY);
+  std::span<uint8_t> s_buf{buf};
+  size_t len;
+  status = signal.get(s_buf, len);
+  ASSERT_EQ(status, PROTON_OK);
+  EXPECT_EQ(len, long_value.size());
+  buf.resize(len);
+  EXPECT_EQ(buf, long_value);
+
+  free(registry.signal_registry);
+}
 
 #endif  // __cplusplus >= 202002L
 


### PR DESCRIPTION
Adding support for `std::string` and `std::vector<uint8_t>` to represent the string and bytes types in C++ when `PROTON_ALLOW_ALLOC` is enabled.

Also:
- add span-based access when std >= C++20 
- Fix a bug where it was impossible to clear a bytes type signal in the registry, an empty buffer is `NULL`, but it was being rejected as a nullptr error.