### PR TITLE
Fix sed issue where it was not finding a decimal place correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
             local metric="$1"
             local file="$2"
             if [[ -f "$file" ]]; then
-              grep -E "^ *${metric}\\.+:" "$file" | sed -E 's/.*: *([0-9]+(\\.[0-9]+)?)%.*/\1/' | head -1
+              grep -E "^ *${metric}\\.+:" "$file" | sed -E 's/.*: *([0-9]+(\.[0-9]+)?)%.*/\1/' | head -1
             else
               echo ""
             fi


### PR DESCRIPTION
lcov comments were always showing the line/function coverage difference as 0. That job was largely copilot-generated so I was okay with ignoring it but it was getting annoying.