### PR TITLE
Fix: only send bundles node produces

### DIFF
--- a/core/src/node_manager.c
+++ b/core/src/node_manager.c
@@ -188,14 +188,19 @@ proton_status_e proton_node_update(
   {
     bundle_desc_t * bundle_desc = &node->registry->bundle_table[i];
 
+    // Don't send bundles that aren't supposed to be sent by this node.
     bool node_is_producer = false;
-    for (uint32_t j = 0; j < bundle_desc->producer_ids.count; j++)
+    for (uint8_t j = 0; j < bundle_desc->producer_ids.count; j++)
     {
       if (node->id == bundle_desc->producer_ids.ids[j])
       {
         node_is_producer = true;
         break;
       }
+    }
+    if (!node_is_producer)
+    {
+      continue;
     }
     // Check triggered bundles
     if (bundle_desc->send_now)
@@ -221,8 +226,7 @@ proton_status_e proton_node_update(
       }
     }
     // No triggered bundles, check non-triggered bundles for the most overdue bundle to send
-    // Don't send bundles that aren't supposed to be sent by this node.
-    else if (!send_now_flag && node_is_producer)
+    else if (!send_now_flag)
     {
       if (bundle_desc->period_ms != 0)
       {

--- a/core/src/node_manager.c
+++ b/core/src/node_manager.c
@@ -93,6 +93,24 @@ static proton_status_e proton_node_encode_bundle_desc(
     node->registry, bundle_handle->bundle_id, buffer, buffer_len, out_len);
 }
 
+/**
+ * @brief Determine if the node is a producer of a particular bundle
+ */
+static bool proton_node_is_producer(uint32_t node_id, const proton_id_list_t * bundle_id_list)
+{
+  bool node_is_producer = false;
+  for (uint8_t i = 0; i < bundle_id_list->count; i++)
+  {
+    if (node_id == bundle_id_list->ids[i])
+    {
+      node_is_producer = true;
+      break;
+    }
+  }
+
+  return node_is_producer;
+}
+
 proton_status_e proton_node_receive(proton_node_t * node, const uint8_t * buffer, size_t len)
 {
   if (node == NULL || node->registry == NULL || buffer == NULL)
@@ -189,16 +207,7 @@ proton_status_e proton_node_update(
     bundle_desc_t * bundle_desc = &node->registry->bundle_table[i];
 
     // Don't send bundles that aren't supposed to be sent by this node.
-    bool node_is_producer = false;
-    for (uint8_t j = 0; j < bundle_desc->producer_ids.count; j++)
-    {
-      if (node->id == bundle_desc->producer_ids.ids[j])
-      {
-        node_is_producer = true;
-        break;
-      }
-    }
-    if (!node_is_producer)
+    if (!proton_node_is_producer(node->id, &bundle_desc->producer_ids))
     {
       continue;
     }
@@ -288,17 +297,7 @@ proton_status_e proton_node_trigger_bundle(proton_node_t * node, uint32_t bundle
   }
   else
   {
-    bool node_is_producer = false;
-    for (uint8_t i = 0; i < bundle_desc->producer_ids.count; i++)
-    {
-      if (node->id == bundle_desc->producer_ids.ids[i])
-      {
-        node_is_producer = true;
-        break;
-      }
-    }
-
-    if (node_is_producer)
+    if (proton_node_is_producer(node->id, &bundle_desc->producer_ids))
     {
       size_t next_head = (node->trigger_head + 1) % PROTON_MAX_PENDING_TRIGGERS;
       if (next_head == node->trigger_tail)

--- a/core/src/node_manager.c
+++ b/core/src/node_manager.c
@@ -282,22 +282,39 @@ proton_status_e proton_node_trigger_bundle(proton_node_t * node, uint32_t bundle
   size_t slot_id;
   const bundle_desc_t * bundle_desc =
     proton_registry_get_bundle(node->registry, bundle_id, &slot_id);
-  if (bundle_desc == NULL)
+  if (bundle_desc == NULL || bundle_desc->producer_ids.ids == NULL)
   {
     trig_ret = PROTON_INCORRECT_TARGET_ERROR;
   }
   else
   {
-    size_t next_head = (node->trigger_head + 1) % PROTON_MAX_PENDING_TRIGGERS;
-    if (next_head == node->trigger_tail)
+    bool node_is_producer = false;
+    for (uint8_t i = 0; i < bundle_desc->producer_ids.count; i++)
     {
-      // Trigger buffer is full, cannot accept new triggers
-      trig_ret = PROTON_INSUFFICIENT_BUFFER_ERROR;
+      if (node->id == bundle_desc->producer_ids.ids[i])
+      {
+        node_is_producer = true;
+        break;
+      }
+    }
+
+    if (node_is_producer)
+    {
+      size_t next_head = (node->trigger_head + 1) % PROTON_MAX_PENDING_TRIGGERS;
+      if (next_head == node->trigger_tail)
+      {
+        // Trigger buffer is full, cannot accept new triggers
+        trig_ret = PROTON_INSUFFICIENT_BUFFER_ERROR;
+      }
+      else
+      {
+        node->pending_triggers[node->trigger_head] = slot_id;
+        node->trigger_head = next_head;
+      }
     }
     else
     {
-      node->pending_triggers[node->trigger_head] = slot_id;
-      node->trigger_head = next_head;
+      trig_ret = PROTON_INCORRECT_TARGET_ERROR;
     }
   }
 

--- a/core/src/node_manager.c
+++ b/core/src/node_manager.c
@@ -187,6 +187,16 @@ proton_status_e proton_node_update(
   for (size_t i = 0; i < node->registry->bundle_count; i++)
   {
     bundle_desc_t * bundle_desc = &node->registry->bundle_table[i];
+
+    bool node_is_producer = false;
+    for (uint32_t j = 0; j < bundle_desc->producer_ids.count; j++)
+    {
+      if (node->id == bundle_desc->producer_ids.ids[j])
+      {
+        node_is_producer = true;
+        break;
+      }
+    }
     // Check triggered bundles
     if (bundle_desc->send_now)
     {
@@ -211,7 +221,8 @@ proton_status_e proton_node_update(
       }
     }
     // No triggered bundles, check non-triggered bundles for the most overdue bundle to send
-    else if (!send_now_flag)
+    // Don't send bundles that aren't supposed to be sent by this node.
+    else if (!send_now_flag && node_is_producer)
     {
       if (bundle_desc->period_ms != 0)
       {

--- a/core/tests/core/multi_node_test.cpp
+++ b/core/tests/core/multi_node_test.cpp
@@ -30,18 +30,19 @@ extern proton_node_t g_target_node;
 
 TEST(NodeManagerTest, BundleForMultipleNodes)
 {
-  g_target_node.registry = &g_proton_registry;
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  proton_node_t node = copy_default_node(&g_target_node);
+  node.registry = &registry;
   uint8_t buf[BUFFER_SIZE];
   size_t out_len = 0;
   static constexpr size_t num_endpoints = 2;
   proton_endpoint_t dest[num_endpoints];
   size_t num_peers = 0;
 
-  proton_node_trigger_bundle(&g_target_node, PROTON_BUNDLE_NODE1_HEARTBEAT_ID);
+  proton_node_trigger_bundle(&node, PROTON_BUNDLE_NODE1_HEARTBEAT_ID);
 
   ASSERT_EQ(
-    proton_node_update(
-      &g_target_node, 1000, buf, sizeof(buf), &out_len, dest, num_endpoints, &num_peers),
+    proton_node_update(&node, 1000, buf, sizeof(buf), &out_len, dest, num_endpoints, &num_peers),
     PROTON_OK);
 
   EXPECT_GT(out_len, 0);
@@ -54,6 +55,27 @@ TEST(NodeManagerTest, BundleForMultipleNodes)
   EXPECT_EQ(dest[1].node_id, static_cast<uint32_t>(PROTON_NODE_NODE3_ID));
   EXPECT_EQ(dest[1].endpoint_id, static_cast<uint32_t>(PROTON_NODE_NODE3_ENDPOINT_0_ID));
   EXPECT_EQ(dest[1].transport_type, PROTON_NODE_NODE3_ENDPOINT_0_TRANSPORT);
+}
+
+TEST(NodeManagerTest, DoNotSendBundlesWhereNodeIsNotProducer)
+{
+  proton_registry_t registry = copy_default_registry(&g_proton_registry);
+  proton_node_t node = copy_default_node(&g_target_node);
+  node.registry = &registry;
+  uint8_t buf[BUFFER_SIZE];
+  size_t out_len = 0;
+  static constexpr size_t num_endpoints = 2;
+  proton_endpoint_t dest[num_endpoints];
+  size_t num_peers = 0;
+
+  proton_node_trigger_bundle(&node, PROTON_BUNDLE_NODE2_HEARTBEAT_ID);
+
+  ASSERT_EQ(
+    proton_node_update(&node, 1000, buf, sizeof(buf), &out_len, dest, num_endpoints, &num_peers),
+    PROTON_OK);
+
+  EXPECT_EQ(out_len, 0);
+  EXPECT_EQ(num_peers, 0);
 }
 
 int main(int argc, char ** argv)

--- a/core/tests/core/multi_node_test.cpp
+++ b/core/tests/core/multi_node_test.cpp
@@ -62,20 +62,10 @@ TEST(NodeManagerTest, DoNotSendBundlesWhereNodeIsNotProducer)
   proton_registry_t registry = copy_default_registry(&g_proton_registry);
   proton_node_t node = copy_default_node(&g_target_node);
   node.registry = &registry;
-  uint8_t buf[BUFFER_SIZE];
-  size_t out_len = 0;
-  static constexpr size_t num_endpoints = 2;
-  proton_endpoint_t dest[num_endpoints];
-  size_t num_peers = 0;
 
-  proton_node_trigger_bundle(&node, PROTON_BUNDLE_NODE2_HEARTBEAT_ID);
-
-  ASSERT_EQ(
-    proton_node_update(&node, 1000, buf, sizeof(buf), &out_len, dest, num_endpoints, &num_peers),
-    PROTON_OK);
-
-  EXPECT_EQ(out_len, 0);
-  EXPECT_EQ(num_peers, 0);
+  EXPECT_EQ(
+    proton_node_trigger_bundle(&node, PROTON_BUNDLE_NODE2_HEARTBEAT_ID),
+    PROTON_INCORRECT_TARGET_ERROR);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
Pretty stupid one, the node manager wasn't checking whether the node should actually produce bundles in the registry.