### PR TITLE
Add baud rate to serial transport config

### DIFF
--- a/cpp/include/protoncpp/node_builder/config.hpp
+++ b/cpp/include/protoncpp/node_builder/config.hpp
@@ -54,6 +54,7 @@ inline constexpr std::string_view TYPE = "type";
 inline constexpr std::string_view IP = "ip";
 inline constexpr std::string_view PORT = "port";
 inline constexpr std::string_view DEVICE = "device";
+inline constexpr std::string_view BAUD = "baud";
 inline constexpr std::string_view CONNECTIONS = "connections";
 inline constexpr std::string_view FIRST = "first";
 inline constexpr std::string_view SECOND = "second";
@@ -139,6 +140,7 @@ struct EndpointConfig
   std::string device;
   std::string ip;
   uint32_t port;
+  uint32_t baud;
 };
 
 struct NodeConfig

--- a/cpp/src/node_builder/config.cpp
+++ b/cpp/src/node_builder/config.cpp
@@ -207,6 +207,7 @@ static EndpointConfig parse_endpoint(const ConfigNode & node)
   const auto ip_node = node[keys::IP];
   const auto port_node = node[keys::PORT];
   const auto device_node = node[keys::DEVICE];
+  const auto baud_node = node[keys::BAUD];
 
   if (endpoint_config.type == transport_types::UDP4)
   {
@@ -224,6 +225,7 @@ static EndpointConfig parse_endpoint(const ConfigNode & node)
       throw NodeBuilderException("serial endpoints require a device");
     }
     endpoint_config.device = device_node.as_string();
+    endpoint_config.baud = baud_node.is_defined() ? baud_node.as_uint32() : 0;
   }
   else
   {

--- a/cpp/tests/node_builder_config_test.cpp
+++ b/cpp/tests/node_builder_config_test.cpp
@@ -264,6 +264,13 @@ TEST(YamlEndpointConfigTest, SerialNoDevice)
     "test_configs/yaml/endpoint_serial_no_device.yaml", "serial endpoints require a device");
 }
 
+TEST(YamlEndpointConfigTest, SpecificBaudRate)
+{
+  Config config = Config::from_yaml("test_configs/yaml/endpoint_serial_specific_baud.yaml");
+  EXPECT_EQ(config.nodes["producer"].endpoints[0].baud, 1234);
+  EXPECT_EQ(config.nodes["consumer"].endpoints[0].baud, 5678);
+}
+
 TEST(YamlNodeConfigTest, NoId)
 {
   expect_yaml_throw_with_message(
@@ -486,6 +493,13 @@ TEST(JsonEndpointConfigTest, SerialNoDevice)
 {
   expect_yaml_throw_with_message(
     "test_configs/json/endpoint_serial_no_device.json", "serial endpoints require a device");
+}
+
+TEST(JsonEndpointConfigTest, SpecificBaudRate)
+{
+  Config config = Config::from_json("test_configs/json/endpoint_serial_specific_baud.json");
+  EXPECT_EQ(config.nodes["producer"].endpoints[0].baud, 1234);
+  EXPECT_EQ(config.nodes["consumer"].endpoints[0].baud, 5678);
 }
 
 TEST(JsonNodeConfigTest, NoId)

--- a/cpp/tests/node_builder_generator_round_trip_test.cpp
+++ b/cpp/tests/node_builder_generator_round_trip_test.cpp
@@ -67,12 +67,12 @@ Config create_round_trip_config()
   NodeConfig node_a;
   node_a.name = "node_a";
   node_a.id = 1;
-  node_a.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.1", 5000};
+  node_a.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.1", 5000, 0};
 
   NodeConfig node_b;
   node_b.name = "node_b";
   node_b.id = 2;
-  node_b.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.2", 5000};
+  node_b.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.2", 5000, 0};
 
   config.nodes["node_a"] = node_a;
   config.nodes["node_b"] = node_b;
@@ -675,12 +675,12 @@ Config create_default_values_config()
   NodeConfig node_a;
   node_a.name = "node_a";
   node_a.id = 1;
-  node_a.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.1", 5000};
+  node_a.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.1", 5000, 0};
 
   NodeConfig node_b;
   node_b.name = "node_b";
   node_b.id = 2;
-  node_b.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.2", 5000};
+  node_b.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.2", 5000, 0};
 
   config.nodes["node_a"] = node_a;
   config.nodes["node_b"] = node_b;
@@ -904,12 +904,12 @@ TEST(InvalidSignalType, InvalidSignalTypeThrows)
   NodeConfig node_a;
   node_a.name = "node_a";
   node_a.id = 1;
-  node_a.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB0", "", 0};
+  node_a.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB0", "", 0, 115200};
 
   NodeConfig node_b;
   node_b.name = "node_b";
   node_b.id = 2;
-  node_b.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB1", "", 0};
+  node_b.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB1", "", 0, 115200};
 
   config.nodes["node_a"] = node_a;
   config.nodes["node_b"] = node_b;
@@ -945,12 +945,12 @@ TEST(InvalidNodeName, InvalidNodeNameThrows)
   NodeConfig node_a;
   node_a.name = "node_a";
   node_a.id = 1;
-  node_a.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB0", "", 0};
+  node_a.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB0", "", 0, 115200};
 
   NodeConfig node_b;
   node_b.name = "node_b";
   node_b.id = 2;
-  node_b.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB1", "", 0};
+  node_b.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB1", "", 0, 115200};
 
   config.nodes["node_a"] = node_a;
   config.nodes["node_b"] = node_b;
@@ -986,12 +986,12 @@ TEST(InvalidTransportTest, InvalidTransportTypeThrows)
   NodeConfig node_a;
   node_a.name = "node_a";
   node_a.id = 1;
-  node_a.endpoints[0] = EndpointConfig{0, "invalid_transport", "", "192.168.1.1", 5000};
+  node_a.endpoints[0] = EndpointConfig{0, "invalid_transport", "", "192.168.1.1", 5000, 0};
 
   NodeConfig node_b;
   node_b.name = "node_b";
   node_b.id = 2;
-  node_b.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.2", 5000};
+  node_b.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.2", 5000, 0};
 
   config.nodes["node_a"] = node_a;
   config.nodes["node_b"] = node_b;
@@ -1012,12 +1012,12 @@ TEST(InvalidTransportTest, SerialTransportIsValid)
   NodeConfig node_a;
   node_a.name = "node_a";
   node_a.id = 1;
-  node_a.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB0", "", 0};
+  node_a.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB0", "", 0, 15200};
 
   NodeConfig node_b;
   node_b.name = "node_b";
   node_b.id = 2;
-  node_b.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB1", "", 0};
+  node_b.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB1", "", 0, 15200};
 
   config.nodes["node_a"] = node_a;
   config.nodes["node_b"] = node_b;
@@ -1055,22 +1055,22 @@ Config create_multi_node_config()
   NodeConfig node_a;
   node_a.name = "node_a";
   node_a.id = 1;
-  node_a.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB0", "", 0};
+  node_a.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB0", "", 0, 9600};
 
   NodeConfig node_b;
   node_b.name = "node_b";
   node_b.id = 2;
-  node_b.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB1", "", 0};
+  node_b.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB1", "", 0, 9600};
 
   NodeConfig node_c;
   node_c.name = "node_c";
   node_c.id = 3;
-  node_c.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB2", "", 0};
+  node_c.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB2", "", 0, 9600};
 
   NodeConfig node_d;
   node_d.name = "node_d";
   node_d.id = 4;
-  node_d.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB3", "", 0};
+  node_d.endpoints[0] = EndpointConfig{0, "serial", "/dev/ttyUSB3", "", 0, 9600};
 
   config.nodes["node_a"] = node_a;
   config.nodes["node_b"] = node_b;

--- a/cpp/tests/node_builder_generator_test.cpp
+++ b/cpp/tests/node_builder_generator_test.cpp
@@ -35,17 +35,17 @@ Config create_base_config()
   NodeConfig node_a;
   node_a.name = "node_a";
   node_a.id = 1;
-  node_a.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.1", 5000};
+  node_a.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.1", 5000, 0};
 
   NodeConfig node_b;
   node_b.name = "node_b";
   node_b.id = 2;
-  node_b.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.2", 5000};
+  node_b.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.2", 5000, 0};
 
   NodeConfig node_c;
   node_c.name = "node_c";
   node_c.id = 3;
-  node_c.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.3", 5000};
+  node_c.endpoints[0] = EndpointConfig{0, "udp4", "", "192.168.1.3", 5000, 0};
 
   config.nodes["node_a"] = node_a;
   config.nodes["node_b"] = node_b;

--- a/cpp/tests/test_configs/json/endpoint_serial_specific_baud.json
+++ b/cpp/tests/test_configs/json/endpoint_serial_specific_baud.json
@@ -1,0 +1,75 @@
+{
+  "nodes": [
+    {
+      "name": "producer",
+      "id": 0,
+      "endpoints": [
+        {
+          "id": 0,
+          "type": "serial",
+          "device": "/dev/ttyUSB0",
+          "baud": 1234
+        }
+      ]
+    },
+    {
+      "name": "consumer",
+      "id": 1,
+      "endpoints": [
+        {
+          "id": 0,
+          "type": "serial",
+          "device": "/dev/ttyUSB1",
+          "baud": 5678
+        }
+      ]
+    }
+  ],
+  "connections": [
+    {
+      "first": {
+        "node": "producer",
+        "id": 0
+      },
+      "second": {
+        "node": "consumer",
+        "id": 0
+      }
+    }
+  ],
+  "signals": [
+    {
+      "name": "double_value",
+      "id": 4096,
+      "type": "double"
+    },
+    {
+      "name": "float_value",
+      "id": 4097,
+      "type": "float"
+    },
+    {
+      "name": "int32_value",
+      "id": 4098,
+      "type": "int32"
+    },
+    {
+      "name": "int64_value",
+      "id": 4099,
+      "type": "int64"
+    }
+  ],
+  "bundles": [
+    {
+      "name": "value_test",
+      "id": 256,
+      "producers": [
+        "producer"
+      ],
+      "consumers": [
+        "consumer"
+      ],
+      "signals": [4096]
+    }
+  ]
+}

--- a/cpp/tests/test_configs/yaml/endpoint_serial_specific_baud.yaml
+++ b/cpp/tests/test_configs/yaml/endpoint_serial_specific_baud.yaml
@@ -1,0 +1,32 @@
+nodes:
+  - name: producer
+    id: 0
+    endpoints:
+      - id: 0
+        type: serial
+        device: /dev/ttyUSB0
+        baud: 1234
+  - name: consumer
+    id: 1
+    endpoints:
+      - id: 0
+        type: serial
+        device: /dev/ttyUSB1
+        baud: 5678
+
+connections:
+  - first: {node: producer, id: 0}
+    second: {node: consumer, id: 0}
+
+signals:
+  - {name: double_value, id: 0x1000, type: double}
+  - {name: float_value, id: 0x1001, type: float}
+  - {name: int32_value, id: 0x1002, type: int32}
+  - {name: int64_value, id: 0x1003, type: int64}
+
+bundles:
+  - name: value_test
+    id: 0x100
+    producers: [producer]
+    consumers: [consumer]
+    signals: [0x1000]

--- a/generator_scripts/config.py
+++ b/generator_scripts/config.py
@@ -34,7 +34,7 @@ def validate_node_elements(node: dict):
     """
     required_top_level_elements = {'name': str, 'endpoints': list[dict]}
     required_endpoint_elements = {'id': str, 'type': 'str'}
-    required_endpoint_configs = {'serial': ['ip', 'port'], 'udp4': ['device']}
+    required_endpoint_configs = {'udp4': ['ip', 'port'], 'serial': ['device', 'baud']}
 
     for tl, tl_type in required_top_level_elements.items():
         if tl not in node:

--- a/generator_scripts/resources/target_connections.h.jinja
+++ b/generator_scripts/resources/target_connections.h.jinja
@@ -38,6 +38,7 @@ extern "C" {
 #define PROTON_NODE_{{ node.name | upper }}_ENDPOINT_{{ ep.id }}_TRANSPORT TRANSPORT_TYPE_{{ ep.type | upper }}
 {% if ep.type == "serial" %}
 #define PROTON_NODE_{{ node.name | upper }}_ENDPOINT_{{ ep.id }}_TRANSPORT_DEVICE "{{ ep.device }}"
+#define PROTON_NODE_{{ node.name | upper }}_ENDPOINT_{{ ep.id }}_TRANSPORT_BAUD "{{ ep.baud }}"
 {% else %}
 #define PROTON_NODE_{{ node.name | upper }}_ENDPOINT_{{ ep.id }}_TRANSPORT_IP "{{ ep.ip }}"
 #define PROTON_NODE_{{ node.name | upper }}_ENDPOINT_{{ ep.id }}_TRANSPORT_IP_LEN {{ ep.ip | length }}


### PR DESCRIPTION
Needed to properly support serial communication in proton_ros2_node.

Thankfully, this is a pretty small change for adding the baud rate to the config, since proton itself doesn't really do anything with it.