### PR TITLE
FIX: Send CRC16 pointer as uint16_t*

### DIFF
--- a/core/include/proton/transport/serial.h
+++ b/core/include/proton/transport/serial.h
@@ -61,7 +61,7 @@ extern "C"
    * @return proton_status_e return status
    */
   proton_status_e proton_serial_fill_crc16(
-    const uint8_t * payload, const uint16_t payload_len, uint8_t * crc);
+    const uint8_t * payload, const uint16_t payload_len, uint16_t * crc);
 
   /**
    * @brief Check for a valid CRC16 in a framed payload

--- a/core/src/transport/serial.c
+++ b/core/src/transport/serial.c
@@ -66,7 +66,7 @@ proton_status_e proton_serial_fill_frame_header(uint8_t * header, const uint16_t
 }
 
 proton_status_e proton_serial_fill_crc16(
-  const uint8_t * payload, const uint16_t payload_len, uint8_t * crc)
+  const uint8_t * payload, const uint16_t payload_len, uint16_t * crc)
 {
   if (!payload || !crc)
   {
@@ -78,8 +78,7 @@ proton_status_e proton_serial_fill_crc16(
 
   if (status == PROTON_OK)
   {
-    crc[0] = (uint8_t)(crc16 & 0xFF);
-    crc[1] = (uint8_t)(crc16 >> 8);
+    *crc = crc16;
   }
 
   return status;

--- a/core/tests/core/serial_transport_test.cpp
+++ b/core/tests/core/serial_transport_test.cpp
@@ -66,8 +66,8 @@ TEST(FillFrameHeader, MaxLength)
 
 TEST(FillCrc16, NullPayloadReturnsError)
 {
-  uint8_t crc[2] = {};
-  EXPECT_EQ(proton_serial_fill_crc16(nullptr, 0, crc), PROTON_NULL_PTR_ERROR);
+  uint16_t crc;
+  EXPECT_EQ(proton_serial_fill_crc16(nullptr, 0, &crc), PROTON_NULL_PTR_ERROR);
 }
 
 TEST(FillCrc16, NullCrcOutputReturnsError)
@@ -80,31 +80,28 @@ TEST(FillCrc16, EmptyPayloadCrcIsAllOnes)
 {
   // CRC initialises to 0xFFFF with no bytes processed
   const uint8_t dummy[1] = {};
-  uint8_t crc[2] = {};
-  ASSERT_EQ(proton_serial_fill_crc16(dummy, 0, crc), PROTON_OK);
-  EXPECT_EQ(crc[0], 0xFF);  // low byte
-  EXPECT_EQ(crc[1], 0xFF);  // high byte
+  uint16_t crc;
+  ASSERT_EQ(proton_serial_fill_crc16(dummy, 0, &crc), PROTON_OK);
+  EXPECT_EQ(crc, 0xFFFF);
 }
 
 TEST(FillCrc16, SingleByteKnownValue)
 {
   // CRC16-CCITT of {0xAB} starting at 0xFFFF = 0xE571
   const uint8_t payload[] = {0xAB};
-  uint8_t crc[2] = {};
-  ASSERT_EQ(proton_serial_fill_crc16(payload, 1, crc), PROTON_OK);
-  EXPECT_EQ(crc[0], 0x71);  // low byte
-  EXPECT_EQ(crc[1], 0xE5);  // high byte
+  uint16_t crc;
+  ASSERT_EQ(proton_serial_fill_crc16(payload, 1, &crc), PROTON_OK);
+  EXPECT_EQ(crc, 0xE571);
 }
 
 TEST(FillCrc16, DeterministicOutput)
 {
   const uint8_t payload[] = {0x01, 0x02, 0x03};
-  uint8_t crc_a[2] = {};
-  uint8_t crc_b[2] = {};
-  ASSERT_EQ(proton_serial_fill_crc16(payload, sizeof(payload), crc_a), PROTON_OK);
-  ASSERT_EQ(proton_serial_fill_crc16(payload, sizeof(payload), crc_b), PROTON_OK);
-  EXPECT_EQ(crc_a[0], crc_b[0]);
-  EXPECT_EQ(crc_a[1], crc_b[1]);
+  uint16_t crc_a;
+  uint16_t crc_b;
+  ASSERT_EQ(proton_serial_fill_crc16(payload, sizeof(payload), &crc_a), PROTON_OK);
+  ASSERT_EQ(proton_serial_fill_crc16(payload, sizeof(payload), &crc_b), PROTON_OK);
+  EXPECT_EQ(crc_a, crc_b);
 }
 
 TEST(FillCrc16, ByteOrderAffectsCrc)
@@ -112,11 +109,11 @@ TEST(FillCrc16, ByteOrderAffectsCrc)
   // Same bytes in different order should produce different CRCs
   const uint8_t payload_a[] = {0x01, 0x02};
   const uint8_t payload_b[] = {0x02, 0x01};
-  uint8_t crc_a[2] = {};
-  uint8_t crc_b[2] = {};
-  ASSERT_EQ(proton_serial_fill_crc16(payload_a, sizeof(payload_a), crc_a), PROTON_OK);
-  ASSERT_EQ(proton_serial_fill_crc16(payload_b, sizeof(payload_b), crc_b), PROTON_OK);
-  EXPECT_FALSE(crc_a[0] == crc_b[0] && crc_a[1] == crc_b[1]);
+  uint16_t crc_a;
+  uint16_t crc_b;
+  ASSERT_EQ(proton_serial_fill_crc16(payload_a, sizeof(payload_a), &crc_a), PROTON_OK);
+  ASSERT_EQ(proton_serial_fill_crc16(payload_b, sizeof(payload_b), &crc_b), PROTON_OK);
+  EXPECT_FALSE(crc_a == crc_b);
 }
 
 // -----------------------------------------------------------------------
@@ -229,23 +226,21 @@ TEST(SerialFraming, FillHeaderThenGetLength_RoundTrip)
 TEST(SerialFraming, FillCrcThenCheckCrc_RoundTrip)
 {
   const uint8_t payload[] = {0xDE, 0xAD, 0xBE, 0xEF};
-  uint8_t crc_bytes[2] = {};
-  ASSERT_EQ(proton_serial_fill_crc16(payload, sizeof(payload), crc_bytes), PROTON_OK);
+  uint16_t crc_bytes;
+  ASSERT_EQ(proton_serial_fill_crc16(payload, sizeof(payload), &crc_bytes), PROTON_OK);
 
-  const uint16_t crc_val = (uint16_t)crc_bytes[0] | ((uint16_t)crc_bytes[1] << 8);
-  EXPECT_EQ(proton_serial_check_framed_payload(payload, sizeof(payload), crc_val), PROTON_OK);
+  EXPECT_EQ(proton_serial_check_framed_payload(payload, sizeof(payload), crc_bytes), PROTON_OK);
 }
 
 TEST(SerialFraming, ModifiedPayloadFailsCrcCheck)
 {
   uint8_t payload[] = {0xDE, 0xAD, 0xBE, 0xEF};
-  uint8_t crc_bytes[2] = {};
-  ASSERT_EQ(proton_serial_fill_crc16(payload, sizeof(payload), crc_bytes), PROTON_OK);
+  uint16_t crc_bytes;
+  ASSERT_EQ(proton_serial_fill_crc16(payload, sizeof(payload), &crc_bytes), PROTON_OK);
 
-  const uint16_t crc_val = (uint16_t)crc_bytes[0] | ((uint16_t)crc_bytes[1] << 8);
   payload[0] ^= 0x01;  // flip one bit
   EXPECT_EQ(
-    proton_serial_check_framed_payload(payload, sizeof(payload), crc_val), PROTON_CRC16_ERROR);
+    proton_serial_check_framed_payload(payload, sizeof(payload), crc_bytes), PROTON_CRC16_ERROR);
 }
 
 int main(int argc, char ** argv)

--- a/cpp/include/protoncpp/transport/core_serial.hpp
+++ b/cpp/include/protoncpp/transport/core_serial.hpp
@@ -43,7 +43,7 @@ inline proton_status_e fill_frame_header(uint8_t * header, const uint16_t payloa
 }
 
 inline proton_status_e fill_crc16(
-  const uint8_t * payload, const uint16_t payload_len, uint8_t * crc)
+  const uint8_t * payload, const uint16_t payload_len, uint16_t * crc)
 {
   return proton_serial_fill_crc16(payload, payload_len, crc);
 }
@@ -61,10 +61,9 @@ inline proton_status_e get_framed_payload_length(const uint8_t * framed_buf, uin
 
 #if __cplusplus >= 202002L
 
-inline proton_status_e fill_crc16(
-  std::span<const uint8_t> payload, std::span<uint8_t, FRAME_CRC_OVERHEAD> crc)
+inline proton_status_e fill_crc16(std::span<const uint8_t> payload, uint16_t * crc)
 {
-  return fill_crc16(payload.data(), static_cast<uint16_t>(payload.size()), crc.data());
+  return fill_crc16(payload.data(), static_cast<uint16_t>(payload.size()), crc);
 }
 
 inline proton_status_e check_framed_payload(

--- a/cpp/tests/serial_transport_test.cpp
+++ b/cpp/tests/serial_transport_test.cpp
@@ -70,8 +70,8 @@ TEST(FillFrameHeader, MaxLength)
 
 TEST(FillCrc16, NullPayloadReturnsError)
 {
-  uint8_t crc[2] = {};
-  EXPECT_EQ(fill_crc16(nullptr, 0, crc), PROTON_NULL_PTR_ERROR);
+  uint16_t crc;
+  EXPECT_EQ(fill_crc16(nullptr, 0, &crc), PROTON_NULL_PTR_ERROR);
 }
 
 TEST(FillCrc16, NullCrcOutputReturnsError)
@@ -84,31 +84,28 @@ TEST(FillCrc16, EmptyPayloadCrcIsAllOnes)
 {
   // CRC initialises to 0xFFFF with no bytes processed
   const uint8_t dummy[1] = {};
-  uint8_t crc[2] = {};
-  ASSERT_EQ(fill_crc16(dummy, 0, crc), PROTON_OK);
-  EXPECT_EQ(crc[0], 0xFF);  // low byte
-  EXPECT_EQ(crc[1], 0xFF);  // high byte
+  uint16_t crc;
+  ASSERT_EQ(fill_crc16(dummy, 0, &crc), PROTON_OK);
+  EXPECT_EQ(crc, 0xFFFF);
 }
 
 TEST(FillCrc16, SingleByteKnownValue)
 {
   // CRC16-CCITT of {0xAB} starting at 0xFFFF = 0xE571
   const uint8_t payload[] = {0xAB};
-  uint8_t crc[2] = {};
-  ASSERT_EQ(fill_crc16(payload, 1, crc), PROTON_OK);
-  EXPECT_EQ(crc[0], 0x71);  // low byte
-  EXPECT_EQ(crc[1], 0xE5);  // high byte
+  uint16_t crc;
+  ASSERT_EQ(fill_crc16(payload, 1, &crc), PROTON_OK);
+  EXPECT_EQ(crc, 0xE571);
 }
 
 TEST(FillCrc16, DeterministicOutput)
 {
   const uint8_t payload[] = {0x01, 0x02, 0x03};
-  uint8_t crc_a[2] = {};
-  uint8_t crc_b[2] = {};
-  ASSERT_EQ(fill_crc16(payload, sizeof(payload), crc_a), PROTON_OK);
-  ASSERT_EQ(fill_crc16(payload, sizeof(payload), crc_b), PROTON_OK);
-  EXPECT_EQ(crc_a[0], crc_b[0]);
-  EXPECT_EQ(crc_a[1], crc_b[1]);
+  uint16_t crc_a;
+  uint16_t crc_b;
+  ASSERT_EQ(fill_crc16(payload, sizeof(payload), &crc_a), PROTON_OK);
+  ASSERT_EQ(fill_crc16(payload, sizeof(payload), &crc_b), PROTON_OK);
+  EXPECT_EQ(crc_a, crc_b);
 }
 
 TEST(FillCrc16, ByteOrderAffectsCrc)
@@ -116,11 +113,11 @@ TEST(FillCrc16, ByteOrderAffectsCrc)
   // Same bytes in different order should produce different CRCs
   const uint8_t payload_a[] = {0x01, 0x02};
   const uint8_t payload_b[] = {0x02, 0x01};
-  uint8_t crc_a[2] = {};
-  uint8_t crc_b[2] = {};
-  ASSERT_EQ(fill_crc16(payload_a, sizeof(payload_a), crc_a), PROTON_OK);
-  ASSERT_EQ(fill_crc16(payload_b, sizeof(payload_b), crc_b), PROTON_OK);
-  EXPECT_FALSE(crc_a[0] == crc_b[0] && crc_a[1] == crc_b[1]);
+  uint16_t crc_a;
+  uint16_t crc_b;
+  ASSERT_EQ(fill_crc16(payload_a, sizeof(payload_a), &crc_a), PROTON_OK);
+  ASSERT_EQ(fill_crc16(payload_b, sizeof(payload_b), &crc_b), PROTON_OK);
+  EXPECT_FALSE(crc_a == crc_b);
 }
 
 // -----------------------------------------------------------------------
@@ -229,22 +226,19 @@ TEST(SerialFraming, FillHeaderThenGetLength_RoundTrip)
 TEST(SerialFraming, FillCrcThenCheckCrc_RoundTrip)
 {
   const uint8_t payload[] = {0xDE, 0xAD, 0xBE, 0xEF};
-  uint8_t crc_bytes[2] = {};
-  ASSERT_EQ(fill_crc16(payload, sizeof(payload), crc_bytes), PROTON_OK);
-
-  const uint16_t crc_val = (uint16_t)crc_bytes[0] | ((uint16_t)crc_bytes[1] << 8);
-  EXPECT_EQ(check_framed_payload(payload, sizeof(payload), crc_val), PROTON_OK);
+  uint16_t crc_bytes;
+  ASSERT_EQ(fill_crc16(payload, sizeof(payload), &crc_bytes), PROTON_OK);
+  EXPECT_EQ(check_framed_payload(payload, sizeof(payload), crc_bytes), PROTON_OK);
 }
 
 TEST(SerialFraming, ModifiedPayloadFailsCrcCheck)
 {
   uint8_t payload[] = {0xDE, 0xAD, 0xBE, 0xEF};
-  uint8_t crc_bytes[2] = {};
-  ASSERT_EQ(fill_crc16(payload, sizeof(payload), crc_bytes), PROTON_OK);
+  uint16_t crc_bytes;
+  ASSERT_EQ(fill_crc16(payload, sizeof(payload), &crc_bytes), PROTON_OK);
 
-  const uint16_t crc_val = (uint16_t)crc_bytes[0] | ((uint16_t)crc_bytes[1] << 8);
   payload[0] ^= 0x01;  // flip one bit
-  EXPECT_EQ(check_framed_payload(payload, sizeof(payload), crc_val), PROTON_CRC16_ERROR);
+  EXPECT_EQ(check_framed_payload(payload, sizeof(payload), crc_bytes), PROTON_CRC16_ERROR);
 }
 
 // -----------------------------------------------------------------------
@@ -258,28 +252,26 @@ TEST(SerialFraming, ModifiedPayloadFailsCrcCheck)
 TEST(FillCrc16Span, EmptyPayloadCrcIsAllOnes)
 {
   const std::array<uint8_t, 1> dummy = {};
-  std::array<uint8_t, 2> crc = {};
-  ASSERT_EQ(fill_crc16(std::span{dummy.data(), 0}, crc), PROTON_OK);
-  EXPECT_EQ(crc[0], 0xFF);
-  EXPECT_EQ(crc[1], 0xFF);
+  uint16_t crc;
+  ASSERT_EQ(fill_crc16(std::span{dummy.data(), 0}, &crc), PROTON_OK);
+  EXPECT_EQ(crc, 0xFFFF);
 }
 
 TEST(FillCrc16Span, SingleByteKnownValue)
 {
   const std::array<uint8_t, 1> payload = {0xAB};
-  std::array<uint8_t, 2> crc = {};
-  ASSERT_EQ(fill_crc16(payload, crc), PROTON_OK);
-  EXPECT_EQ(crc[0], 0x71);
-  EXPECT_EQ(crc[1], 0xE5);
+  uint16_t crc;
+  ASSERT_EQ(fill_crc16(payload, &crc), PROTON_OK);
+  EXPECT_EQ(crc, 0xE571);
 }
 
 TEST(FillCrc16Span, DeterministicOutput)
 {
   const std::array<uint8_t, 3> payload = {0x01, 0x02, 0x03};
-  std::array<uint8_t, 2> crc_a = {};
-  std::array<uint8_t, 2> crc_b = {};
-  ASSERT_EQ(fill_crc16(payload, crc_a), PROTON_OK);
-  ASSERT_EQ(fill_crc16(payload, crc_b), PROTON_OK);
+  uint16_t crc_a;
+  uint16_t crc_b;
+  ASSERT_EQ(fill_crc16(payload, &crc_a), PROTON_OK);
+  ASSERT_EQ(fill_crc16(payload, &crc_b), PROTON_OK);
   EXPECT_EQ(crc_a, crc_b);
 }
 
@@ -287,10 +279,10 @@ TEST(FillCrc16Span, ByteOrderAffectsCrc)
 {
   const std::array<uint8_t, 2> payload_a = {0x01, 0x02};
   const std::array<uint8_t, 2> payload_b = {0x02, 0x01};
-  std::array<uint8_t, 2> crc_a = {};
-  std::array<uint8_t, 2> crc_b = {};
-  ASSERT_EQ(fill_crc16(payload_a, crc_a), PROTON_OK);
-  ASSERT_EQ(fill_crc16(payload_b, crc_b), PROTON_OK);
+  uint16_t crc_a;
+  uint16_t crc_b;
+  ASSERT_EQ(fill_crc16(payload_a, &crc_a), PROTON_OK);
+  ASSERT_EQ(fill_crc16(payload_b, &crc_b), PROTON_OK);
   EXPECT_NE(crc_a, crc_b);
 }
 
@@ -374,24 +366,19 @@ TEST(GetFramedPayloadLengthSpan, WrongSecondMagicByteReturnsError)
 TEST(SerialFramingSpan, FillCrcThenCheckCrc_RoundTrip)
 {
   const std::array<uint8_t, 4> payload = {0xDE, 0xAD, 0xBE, 0xEF};
-  std::array<uint8_t, 2> crc_bytes = {};
-  ASSERT_EQ(fill_crc16(payload, crc_bytes), PROTON_OK);
-
-  const uint16_t crc_val =
-    static_cast<uint16_t>(crc_bytes[0]) | (static_cast<uint16_t>(crc_bytes[1]) << 8);
-  EXPECT_EQ(check_framed_payload(payload, crc_val), PROTON_OK);
+  uint16_t crc_bytes;
+  ASSERT_EQ(fill_crc16(payload, &crc_bytes), PROTON_OK);
+  EXPECT_EQ(check_framed_payload(payload, crc_bytes), PROTON_OK);
 }
 
 TEST(SerialFramingSpan, ModifiedPayloadFailsCrcCheck)
 {
   std::array<uint8_t, 4> payload = {0xDE, 0xAD, 0xBE, 0xEF};
-  std::array<uint8_t, 2> crc_bytes = {};
-  ASSERT_EQ(fill_crc16(payload, crc_bytes), PROTON_OK);
+  uint16_t crc_bytes;
+  ASSERT_EQ(fill_crc16(payload, &crc_bytes), PROTON_OK);
 
-  const uint16_t crc_val =
-    static_cast<uint16_t>(crc_bytes[0]) | (static_cast<uint16_t>(crc_bytes[1]) << 8);
   payload[0] ^= 0x01;  // flip one bit
-  EXPECT_EQ(check_framed_payload(payload, crc_val), PROTON_CRC16_ERROR);
+  EXPECT_EQ(check_framed_payload(payload, crc_bytes), PROTON_CRC16_ERROR);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
For whatever reason, the original implementation of `proton_serial_fill_crc16()` accepted a `uint8_t *` for the crc, expecting it to be 2 bytes long (making it a u16). This could just be a `uint16_t *`. This implementation was carried over from proton 1.0.1 during the refactor.

https://github.com/clearpathrobotics/proton/blob/1.0.1/include/proton/common.h#L143